### PR TITLE
[TS] LPS-91094

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view.jsp
@@ -52,8 +52,6 @@ SearchContainer searchContainer = new SearchContainer(renderRequest, null, null,
 
 mbAdminListDisplayContext.setEntriesDelta(searchContainer);
 
-searchContainer.setId("mbEntries");
-
 mbEntriesManagementToolbarDisplayContext.populateOrder(searchContainer);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
@@ -82,7 +80,6 @@ String entriesNavigation = ParamUtil.getString(request, "entriesNavigation", "al
 	filterLabelItems="<%= mbEntriesManagementToolbarDisplayContext.getFilterLabelItems() %>"
 	itemsTotal="<%= searchContainer.getTotal() %>"
 	searchActionURL="<%= mbEntriesManagementToolbarDisplayContext.getSearchActionURL() %>"
-	searchContainerId="mbEntries"
 	searchFormName="searchFm"
 	showInfoButton="<%= false %>"
 	sortingOrder="<%= mbEntriesManagementToolbarDisplayContext.getOrderByType() %>"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-91094

This PR addresses an issue affecting the messageboard toolbar. When a user tries to filter by thread and subsequently by categories, the number of results is not updated, showing only the number results for threads.

According to a comment made by eduardolundgren in [this issue discussion](https://github.com/liferay/senna.js/issues/169), senna.js has a default behavior to paint the first page load contents when a surface object cannot be found. The object in question was found to be searchContainer through testing.

A proposed fix implemented in this PR is to remove the searchContainerId parameter from messageBoard toolbar altogether. This solution was inspired by[ edit_permissions.jsp](https://github.com/liferay/liferay-portal/blob/f95c16873d452aeae63465be99669846f748ca0a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp#L33-L39) in portlet-configuration-web whose toolbar is written without a searchContainerId field. By removing this field, Senna no longer looks for searchContainer, avoiding the check for a surface that it cannot find.

After applying this fix, the messageboard toolbar updates as expected the number of filter results, with no noticeable effect on the portlet's search capabilities.