### PR TITLE
[TS] LPS-93854

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -198,21 +198,21 @@ public class DLAdminDisplayContext {
 	public String getRememberCheckBoxStateURLRegex() {
 		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
 
-		if (DLPortletKeys.DOCUMENT_LIBRARY.equals(
+		if (!DLPortletKeys.DOCUMENT_LIBRARY.equals(
 				portletDisplay.getRootPortletId())) {
 
-			if (_folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-				return "^[^?]+/" + portletDisplay.getInstanceId() + "\\?";
-			}
-
 			return StringBundler.concat(
-				"^[^?]+/", portletDisplay.getInstanceId(), "/view/" + _folderId,
-				"\\?");
+				"^(?!.*", portletDisplay.getNamespace(),
+				"redirect).*(folderId=", _folderId, ")");
+		}
+
+		if (_folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			return "^[^?]+/" + portletDisplay.getInstanceId() + "\\?";
 		}
 
 		return StringBundler.concat(
-			"^(?!.*", portletDisplay.getNamespace(), "redirect).*(folderId=",
-			_folderId, ")");
+			"^[^?]+/", portletDisplay.getInstanceId(), "/view/" + _folderId,
+			"\\?");
 	}
 
 	public long getRepositoryId() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminDisplayContext.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.search.SearchResult;
 import com.liferay.portal.kernel.search.SearchResultUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -192,6 +193,26 @@ public class DLAdminDisplayContext {
 		}
 
 		return orderByType;
+	}
+
+	public String getRememberCheckBoxStateURLRegex() {
+		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
+		if (DLPortletKeys.DOCUMENT_LIBRARY.equals(
+				portletDisplay.getRootPortletId())) {
+
+			if (_folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+				return "^[^?]+/" + portletDisplay.getInstanceId() + "\\?";
+			}
+
+			return StringBundler.concat(
+				"^[^?]+/", portletDisplay.getInstanceId(), "/view/" + _folderId,
+				"\\?");
+		}
+
+		return StringBundler.concat(
+			"^(?!.*", portletDisplay.getNamespace(), "redirect).*(folderId=",
+			_folderId, ")");
 	}
 
 	public long getRepositoryId() {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -41,7 +41,18 @@ portletURL.setParameter("folderId", String.valueOf(folderId));
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 
 entriesChecker.setCssClass("entry-selector");
-entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletResponse.getNamespace() + "redirect).*(folderId=" + String.valueOf(folderId) + ")");
+
+if (DLPortletKeys.DOCUMENT_LIBRARY.equals(portletDisplay.getRootPortletId())) {
+	if (folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+		entriesChecker.setRememberCheckBoxStateURLRegex("^[^?]+/" + portletDisplay.getInstanceId() + "\\?");
+	}
+	else {
+		entriesChecker.setRememberCheckBoxStateURLRegex("^[^?]+/" + portletDisplay.getInstanceId() + "/view/" + folderId + "\\?");
+	}
+}
+else {
+	entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletResponse.getNamespace() + "redirect).*(folderId=" + String.valueOf(folderId) + ")");
+}
 
 EntriesMover entriesMover = new EntriesMover(dlTrashUtil.isTrashEnabled(scopeGroupId, repositoryId));
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -42,17 +42,7 @@ EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, lifera
 
 entriesChecker.setCssClass("entry-selector");
 
-if (DLPortletKeys.DOCUMENT_LIBRARY.equals(portletDisplay.getRootPortletId())) {
-	if (folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-		entriesChecker.setRememberCheckBoxStateURLRegex("^[^?]+/" + portletDisplay.getInstanceId() + "\\?");
-	}
-	else {
-		entriesChecker.setRememberCheckBoxStateURLRegex("^[^?]+/" + portletDisplay.getInstanceId() + "/view/" + folderId + "\\?");
-	}
-}
-else {
-	entriesChecker.setRememberCheckBoxStateURLRegex("^(?!.*" + liferayPortletResponse.getNamespace() + "redirect).*(folderId=" + String.valueOf(folderId) + ")");
-}
+entriesChecker.setRememberCheckBoxStateURLRegex(dlAdminDisplayContext.getRememberCheckBoxStateURLRegex());
 
 EntriesMover entriesMover = new EntriesMover(dlTrashUtil.isTrashEnabled(scopeGroupId, repositoryId));
 

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
@@ -68,7 +68,7 @@ public class SharingUserAutocompleteMVCResourceCommand
 		HttpServletRequest request = _portal.getHttpServletRequest(
 			resourceRequest);
 
-		JSONArray usersJSONArray = getUsersJSONArray(request);
+		JSONArray usersJSONArray = _getUsersJSONArray(request);
 
 		HttpServletResponse response = _portal.getHttpServletResponse(
 			resourceResponse);
@@ -79,7 +79,7 @@ public class SharingUserAutocompleteMVCResourceCommand
 			resourceRequest, resourceResponse, usersJSONArray);
 	}
 
-	protected JSONArray getUsersJSONArray(HttpServletRequest request)
+	private JSONArray _getUsersJSONArray(HttpServletRequest request)
 		throws PortalException {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
@@ -133,7 +133,8 @@ public class SharingUserAutocompleteMVCResourceCommand
 		User user = themeDisplay.getUser();
 
 		return _userLocalService.searchSocial(
-			themeDisplay.getCompanyId(), user.getGroupIds(), query, 0, 20);
+			themeDisplay.getCompanyId(), user.getGroupIds(), query, 0, 20,
+			new UserScreenNameComparator());
 	}
 
 	@Reference

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
@@ -79,6 +79,28 @@ public class SharingUserAutocompleteMVCResourceCommand
 			resourceRequest, resourceResponse, usersJSONArray);
 	}
 
+	private List<User> _getUsers(
+		HttpServletRequest request, ThemeDisplay themeDisplay) {
+
+		String query = ParamUtil.getString(request, "query");
+
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
+		if (permissionChecker.isCompanyAdmin()) {
+			return _userLocalService.search(
+				themeDisplay.getCompanyId(), query,
+				WorkflowConstants.STATUS_APPROVED, new LinkedHashMap<>(), 0, 20,
+				new UserScreenNameComparator());
+		}
+
+		User user = themeDisplay.getUser();
+
+		return _userLocalService.searchSocial(
+			themeDisplay.getCompanyId(), user.getGroupIds(), query, 0, 20,
+			new UserScreenNameComparator());
+	}
+
 	private JSONArray _getUsersJSONArray(HttpServletRequest request)
 		throws PortalException {
 
@@ -113,28 +135,6 @@ public class SharingUserAutocompleteMVCResourceCommand
 		}
 
 		return jsonArray;
-	}
-
-	private List<User> _getUsers(
-		HttpServletRequest request, ThemeDisplay themeDisplay) {
-
-		String query = ParamUtil.getString(request, "query");
-
-		PermissionChecker permissionChecker =
-			themeDisplay.getPermissionChecker();
-
-		if (permissionChecker.isCompanyAdmin()) {
-			return _userLocalService.search(
-				themeDisplay.getCompanyId(), query,
-				WorkflowConstants.STATUS_APPROVED, new LinkedHashMap<>(), 0, 20,
-				new UserScreenNameComparator());
-		}
-
-		User user = themeDisplay.getUser();
-
-		return _userLocalService.searchSocial(
-			themeDisplay.getCompanyId(), user.getGroupIds(), query, 0, 20,
-			new UserScreenNameComparator());
 	}
 
 	@Reference

--- a/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
+++ b/modules/apps/sharing/sharing-web/src/main/java/com/liferay/sharing/web/internal/portlet/action/SharingUserAutocompleteMVCResourceCommand.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -119,10 +120,20 @@ public class SharingUserAutocompleteMVCResourceCommand
 
 		String query = ParamUtil.getString(request, "query");
 
-		return _userLocalService.search(
-			themeDisplay.getCompanyId(), query,
-			WorkflowConstants.STATUS_APPROVED, new LinkedHashMap<>(), 0, 20,
-			new UserScreenNameComparator());
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
+		if (permissionChecker.isCompanyAdmin()) {
+			return _userLocalService.search(
+				themeDisplay.getCompanyId(), query,
+				WorkflowConstants.STATUS_APPROVED, new LinkedHashMap<>(), 0, 20,
+				new UserScreenNameComparator());
+		}
+
+		User user = themeDisplay.getUser();
+
+		return _userLocalService.searchSocial(
+			themeDisplay.getCompanyId(), user.getGroupIds(), query, 0, 20);
 	}
 
 	@Reference

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
@@ -148,11 +148,13 @@ public class RecentGroupManager {
 				continue;
 			}
 
+			String friendlyURL = group.getFriendlyURL();
+
 			Layout layout = _layoutLocalService.fetchFirstLayout(
 				group.getGroupId(), false,
 				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-			if (layout == null) {
+			if ((layout == null) && !friendlyURL.equals("/global")) {
 				layout = _layoutLocalService.fetchFirstLayout(
 					group.getGroupId(), true,
 					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -3590,6 +3590,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	public List<User> searchSocial(
 		long companyId, long[] groupIds, String keywords, int start, int end) {
 
+		return searchSocial(companyId, groupIds, keywords, start, end, null);
+	}
+
+	@Override
+	public List<User> searchSocial(
+		long companyId, long[] groupIds, String keywords, int start, int end,
+		OrderByComparator<User> obc) {
+
 		LinkedHashMap<String, Object> params = new LinkedHashMap<>();
 
 		params.put("usersGroups", ArrayUtil.toLongArray(groupIds));
@@ -3597,7 +3605,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		return userFinder.findByKeywords(
 			companyId, keywords, WorkflowConstants.STATUS_APPROVED, params,
-			start, end, null);
+			start, end, obc);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -1913,6 +1913,11 @@ public interface UserLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<User> searchSocial(
+		long companyId, long[] groupIds, String keywords, int start, int end,
+		OrderByComparator<User> obc);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<User> searchSocial(
 			long[] groupIds, long userId, int[] socialRelationTypes,
 			String keywords, int start, int end)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
@@ -2494,6 +2494,17 @@ public class UserLocalServiceUtil {
 	}
 
 	public static java.util.List<com.liferay.portal.kernel.model.User>
+		searchSocial(
+			long companyId, long[] groupIds, String keywords, int start,
+			int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.portal.kernel.model.User> obc) {
+
+		return getService().searchSocial(
+			companyId, groupIds, keywords, start, end, obc);
+	}
+
+	public static java.util.List<com.liferay.portal.kernel.model.User>
 			searchSocial(
 				long[] groupIds, long userId, int[] socialRelationTypes,
 				String keywords, int start, int end)

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
@@ -2656,6 +2656,16 @@ public class UserLocalServiceWrapper
 
 	@Override
 	public java.util.List<com.liferay.portal.kernel.model.User> searchSocial(
+		long companyId, long[] groupIds, String keywords, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator
+			<com.liferay.portal.kernel.model.User> obc) {
+
+		return _userLocalService.searchSocial(
+			companyId, groupIds, keywords, start, end, obc);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.User> searchSocial(
 			long[] groupIds, long userId, int[] socialRelationTypes,
 			String keywords, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93854

Issue:
The global site does not appear as a selectable choice within recent sites tab.

Cause:
Global is currently being stored as a recent site, but was never shown because it is missing a layout unlike most other sites. In getRecentGroups of RecentGroupManager.java, the method [_layoutLocalService.fetchFirstLayout](https://github.com/liferay/liferay-portal-ee/blob/f3b09b6dad2de323ca061753955681587ad68c8f/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java#L151-L153) returns null for global, and global is never added to the groups list.

Fix:
A layout is not necessary for a site to display correctly in recent tab. Get the friendlyURL from group and check if it is "/global". Allow the current groupId to be added to the groups list if this is true, so global can be included as a recent site.