### PR TITLE
[TS] LPS-93854

### DIFF
--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
@@ -148,11 +148,13 @@ public class RecentGroupManager {
 				continue;
 			}
 
+			String friendlyURL = group.getFriendlyURL();
+
 			Layout layout = _layoutLocalService.fetchFirstLayout(
 				group.getGroupId(), false,
 				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-			if (layout == null) {
+			if ((layout == null) && !friendlyURL.equals("/global")) {
 				layout = _layoutLocalService.fetchFirstLayout(
 					group.getGroupId(), true,
 					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93854

Issue:
The global site does not appear as a selectable choice within recent sites tab.

Cause:
Global is currently being stored as a recent site, but was never shown because it is missing a layout unlike most other sites. In getRecentGroups of RecentGroupManager.java, the method [_layoutLocalService.fetchFirstLayout](https://github.com/liferay/liferay-portal-ee/blob/f3b09b6dad2de323ca061753955681587ad68c8f/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java#L151-L153) returns null for global, and global is never added to the groups list.

Fix:
A layout is not necessary for a site to display correctly in recent tab. Get the friendlyURL from group and check if it is "/global". Allow the current groupId to be added to the groups list if this is true, so global can be included as a recent site.