### PR TITLE
[TS] LPS-94833 new account password validation

### DIFF
--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
@@ -171,12 +171,16 @@ renderResponse.setTitle(LanguageUtil.get(request, "create-account"));
 
 		<aui:col width="<%= 50 %>">
 			<c:if test="<%= PropsValues.LOGIN_CREATE_ACCOUNT_ALLOW_CUSTOM_PASSWORD %>">
-				<aui:input label="password" name="password1" size="30" type="password" value="" />
+				<aui:input label="password" name="password1" size="30" type="password" value="">
+					<aui:validator name="required" />
+				</aui:input>
 
 				<aui:input label="enter-again" name="password2" size="30" type="password" value="">
 					<aui:validator name="equalTo">
 						'#<portlet:namespace />password1'
 					</aui:validator>
+
+					<aui:validator name="required" />
 				</aui:input>
 			</c:if>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94833

Issue:
Password and its confirmation do not appear as required fields in Create Account. Currently, the form submission fails with message _The password cannot be blank. Please enter a password._ which is less user friendly than setting the fields as required.

Fix:
Add aui validator tags within create_account.jsp that require non-empty input. Implementation follows the precedent set in [update_password.jsp](https://github.com/liferay/liferay-portal/blob/8a6e78c1174643a4248824e126ffb68d990afa82/portal-web/docroot/html/portal/update_password.jsp#L178-L187).