### PR TITLE
[TS] LPS-94869 unescape change list history

### DIFF
--- a/modules/apps/change-tracking/change-tracking-change-lists-history-web/src/main/resources/META-INF/resources/details.jsp
+++ b/modules/apps/change-tracking/change-tracking-change-lists-history-web/src/main/resources/META-INF/resources/details.jsp
@@ -22,7 +22,7 @@ CTCollection ctCollection = (CTCollection)request.getAttribute(CTWebKeys.CT_COLL
 SearchContainer<CTEntry> ctEntrySearchContainer = changeListsHistoryDisplayContext.getCTCollectionDetailsSearchContainer(ctCollection);
 
 if (ctCollection != null) {
-	String title = HtmlUtil.escapeJS(ctCollection.getName());
+	String title = HtmlUtil.escape(ctCollection.getName());
 
 	portletDisplay.setTitle(title);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94869

Issue:
The change list history title is being displayed as an escaped string and is not human-readable. 

Cause:
The [portletDisplay title](https://github.com/liferay/liferay-portal/blob/fc9548ba2c3511f9bd8a4b0595d7a8eebe5d63d7/modules/apps/change-tracking/change-tracking-change-lists-history-web/src/main/resources/META-INF/resources/details.jsp#L27) is set to an escaped string for use in a javascript context by HTMLUtil's escapeJS() function, however the portletDisplay context is actually html.

Fix:
The two uses of title here are to set the [renderResponse title](https://github.com/liferay/liferay-portal/blob/fc9548ba2c3511f9bd8a4b0595d7a8eebe5d63d7/modules/apps/change-tracking/change-tracking-change-lists-history-web/src/main/resources/META-INF/resources/details.jsp#L29) for a searchContainer in [ ChangeListHistoryDisplayContext.java](https://github.com/liferay/liferay-portal/blob/fc9548ba2c3511f9bd8a4b0595d7a8eebe5d63d7/modules/apps/change-tracking/change-tracking-change-lists-history-web/src/main/java/com/liferay/change/tracking/change/lists/history/web/internal/display/context/ChangeListsHistoryDisplayContext.java#L300) and also the portletDisplay title, which is seen in this issue. Since Javascript is never involved in these instances, we can safely modify this function call to the html version HTMLUtil.escape(), which removes the displayed escape characters in change list history.