### PR TITLE
[TS] LPS-95262 staging site permissions missing for admin

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -1050,8 +1050,17 @@ public class GroupImpl extends GroupBaseImpl {
 					continue;
 				}
 
-				if (portletDataHandler.equals(
-						stagedPortlet.getPortletDataHandlerInstance())) {
+				PortletDataHandler stagedPortletDataHandler =
+					stagedPortlet.getPortletDataHandlerInstance();
+
+				String portletDataHandlerServiceName =
+					portletDataHandler.getServiceName();
+
+				String stagedDataHandlerServiceName =
+					stagedPortletDataHandler.getServiceName();
+
+				if (portletDataHandlerServiceName.equals(
+						stagedDataHandlerServiceName)) {
 
 					return GetterUtil.getBoolean(entry.getValue());
 				}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-95262

Issue:
When staged content is disabled for all portlets, the admin user loses privileges to update content and change permissions in some applications like Documents and Media.

Cause:
In isStagedPortlet() of GroupImpl, two polymorphic objects are compared with the default equals() inherited from Object class. This check fails because it looks at whether PortletDataHandler references point to the same object, when it ought to examine the association between PortletDataHandler and portlet.

Fix:
We only need to verify that portlet classNames are alike here. It is possible to get part of the names through getNamespace() and getServiceName() which are declared in interface PortletDataHandler, and when comparing objects using these String values, admin users retain their permission to edit content in unstaged portlet environments.

Note:
The utilization of portletId for this check does NOT work in this case because DL staging settings are stored under DLAdminPortlet instead of DLPortlet.