### PR TITLE
LPS-92486

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1056,6 +1056,8 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 	public Layout fetchLayoutByFriendlyURL(
 		long groupId, boolean privateLayout, String friendlyURL) {
 
+		friendlyURL = layoutLocalServiceHelper.getFriendlyURL(friendlyURL);
+
 		return layoutPersistence.fetchByG_P_F_Head(
 			groupId, privateLayout, friendlyURL, false);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92486

Issue:
Configuring search bar widget with a destination page friendlyURL that has non-ascii chars results in "This search bar is not visible to users yet. Set up its destination to make it visible."

Cause:
Created layouts have utf-8 encoded friendlyURL fields. Although we have handled encoding correctly for adding, getting and updating Layouts, we forgot to do so for fetchLayoutByFriendlyURL. The mismatch causes fetchByG_P_F_Head to return null, thus the destination page appears unreachable.

Fix:
In order to fix this issue, we can make use of helper method [getFriendlyURL()](https://github.com/liferay/liferay-portal/blob/62f42f454a8485b3d7a5b41d67b1822002a4b53c/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java#L116). The returned String will have utf-8 encoding. After adding this change, search bar widget can accept non-ascii characters in destination pages.