### PR TITLE
LPS-98019

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -188,6 +188,8 @@ public class PortletPreferencesLocalServiceImpl
 		long companyId, long ownerId, int ownerType, long plid,
 		String portletId) {
 
+		plid = _swapPlidForPortletPreferences(plid);
+
 		PortletPreferences portletPreferences =
 			portletPreferencesPersistence.fetchByO_O_P_P(
 				ownerId, ownerType, plid, portletId);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-98019

Issue:
Keyword name of search bar cannot be modified from configurations once staging is enabled. 

Cause:
We swap the plids of themeDisplays passed into PortletPreferencesLocalServiceImpl.java for plids associated with LayoutRevisions. This was likely implemented due to inconsistencies of plid between themeDisplays of staged and live sites. Since we had added the _swapPlidForPortletPreferences() call to get, add, and update methods and forgot it in fetchPortletPreferences(), it creates the issue where either the wrong preferences or null is fetched.

Fix:
Since we had passed in the plid for [themeDisplay](https://github.com/liferay/liferay-portal/blob/7.1.x/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/preferences/PortletPreferencesLookupImpl.java#L50) rather than LayoutRevision, we simply need to utilize _swapPlidForPortletPreferences() for fetching portletPreferences. Then, the correct database table row is fetched and the keyword name can be updated.