### PR TITLE
LPS-98054

### DIFF
--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/application/list/StagingProcessesPanelApp.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/application/list/StagingProcessesPanelApp.java
@@ -17,7 +17,10 @@ package com.liferay.staging.processes.web.internal.application.list;
 import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.staging.constants.StagingProcessesPortletKeys;
 
 import org.osgi.service.component.annotations.Component;
@@ -39,6 +42,17 @@ public class StagingProcessesPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return StagingProcessesPortletKeys.STAGING_PROCESSES;
+	}
+
+	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		if (group.isUser() || group.isUserGroup()) {
+			return false;
+		}
+
+		return super.isShow(permissionChecker, group);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-98054

Issue:
Staging a personal site or user group site causes error DataIntegrityViolationException, and cannot be enabled.

Fix:
This fix is pretty straightforward. After discussion with SME, it was decided that the staging button ought to not be displayed on these sites, so in this change I just removed Product Menu access to staging.