### PR TITLE
LPS-99216 DDM Image Description field is not required

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/dependencies/ddm/image.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/dependencies/ddm/image.ftl
@@ -75,7 +75,9 @@
 				value="preview"
 			/>
 		</div>
+	</div>
 
+	<div class="form-group">
 		<@liferay_aui.input
 			label="image-description"
 			name="${namespacedFieldName}Alt"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-99216

Issue:
Although image descriptions are not required, they show red and green highlighting as if validation occurs for it.

Fix:
This fix is straightforward. We should move description input tag into its own div, so that highlighting just occurs for the image field.