### PR TITLE
LPS-100833 Add missing empty string check in DDM SelectField

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3672,7 +3672,11 @@ AUI.add(
 					var instance = this;
 
 					if (Lang.isString(value)) {
-						value = JSON.parse(value);
+						if (value !== '') {
+							value = JSON.parse(value);
+						} else {
+							value = [""];
+						}
 					}
 
 					instance


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-100833

Issue:
Adding a Select Field to Web Content causes it to be un-editable, and inputs are frozen.

Fix:
Existing code needed a check for empty Strings surrounding the parse call. These were present in other setValue() functions of ddm_form.js such as DocumentLibrary and Date Fields, but were not found for Select Field.