### PR TITLE
[TS] LPS-101687 

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -875,6 +875,12 @@ AUI.add(
 				repeat() {
 					var instance = this;
 
+					instance.get('definition').fields.forEach(function(item) {
+						if(item.type === "select") {
+							item.options.shift();
+						}
+					});
+
 					instance._getTemplate(function(fieldTemplate) {
 						var field = instance.createField(fieldTemplate);
 
@@ -3595,7 +3601,9 @@ AUI.add(
 
 					var fieldOptions = fieldDefinition.options;
 
-					fieldOptions.unshift(instance._getPlaceholderOption());
+					if (fieldOptions && fieldOptions[0].label[instance.get('displayLocale')]!=='') {
+						fieldOptions.unshift(instance._getPlaceholderOption());
+					}
 
 					return fieldOptions;
 				},


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-101687

Issue:
When a select field is repeated, every new instance gains an extra blank placeholder option.

Context:
The problem is that getOptions() adds a placeholder into the field definition and submits the current form with that addition in getTemplate(). This causes the options var to become out of sync with the actual html elements.

Fix:
We should limit how many blank options are added to the options list, and also ensure the placeholder gets removed before getTemplate() resource requests. After this change, the select field no longer adds unneeded placeholder options.