### PR TITLE
LPS-102403 Revert "LPS-101544 DDM Form defaultLocale should not updat…

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -135,11 +135,7 @@
 
 			var ddmFormDefinition = <%= DDMUtil.getDDMFormJSONString(ddmForm) %>;
 
-			var availableLanguageIds = ddmFormDefinition.availableLanguageIds;
-
-			if (availableLanguageIds.includes('<%= LocaleUtil.toLanguageId(defaultLocale) %>')) {
-				ddmFormDefinition.defaultLanguageId = '<%= LocaleUtil.toLanguageId(defaultLocale) %>';
-			}
+			ddmFormDefinition.defaultLanguageId = '<%= LocaleUtil.toLanguageId(defaultLocale) %>';
 
 			var liferayDDMForm = Liferay.component(
 				'<portlet:namespace /><%= HtmlUtil.escapeJS(fieldsNamespace) %>ddmForm',


### PR DESCRIPTION
…changes

https://issues.liferay.com/browse/LPS-102403

Partial revert of [LPS-101544](https://issues.liferay.com/browse/LPS-101544) as regression testing found an error message when saving web content.

The root cause for LPS-101544 is the first displayed language should be one that appears in AvailableLocales, which does not initially contain the default or current locale when default site language is changed. 

The "current locale" needs to be preset separately from the default, and this will be achieved in feature request [LPS-95929](https://issues.liferay.com/browse/LPS-95929). Thus, the probability of writing an alternative fix is unlikely until LPS-95929 is implemented.