### PR TITLE
LPS-102798 Cannot access Blogs entry via blogs widget on a content page

### DIFF
--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
@@ -713,6 +713,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 		Set<String> privateRenderParameterNames = new LinkedHashSet<>();
 
+		final String instance_0_ = "INSTANCE_0_";
+
 		if (portletFocus) {
 			Map<String, String[]> privateRenderParameters = null;
 
@@ -720,8 +722,28 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 				httpServletRequest.getParameterMap();
 
 			for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+				String key = entry.getKey();
+
+				if (!portlet.isInstanceable() && (portletNamespace != null) &&
+					portletNamespace.contains(instance_0_) &&
+					!key.contains(instance_0_)) {
+
+					String originalPortletNamespace =
+						portletNamespace.substring(
+							0, portletNamespace.indexOf(instance_0_));
+
+					if (portletNamespace.contains(instance_0_) &&
+						(key.length() >= originalPortletNamespace.length())) {
+
+						String parameter = key.substring(
+							originalPortletNamespace.length());
+
+						key = portletNamespace + parameter;
+					}
+				}
+
 				RequestParameter requestParameter = new RequestParameter(
-					entry.getKey(), entry.getValue(), portletNamespace,
+					key, entry.getValue(), portletNamespace,
 					_portletSpecMajorVersion);
 
 				if (requestParameter.isNameInvalid()) {


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-102798

Caused by: https://issues.liferay.com/browse/LPS-96828
- mvcRenderCommand and urlTitle parameters were not passed up as they did not contain "INSTANCE_0_" in the name (`_com_liferay_blogs_web_portlet_BlogsPortlet_urlTitle` vs `_com_liferay_blogs_web_portlet_BlogsPortlet_INSTANCE_0_urlTitle`). The portlet namespace `_com_liferay_blogs_web_portlet_BlogsPortlet_INSTANCE_0_` did not prepend the parameters (i.e. they were not namespaced), causing the params to bypass the dynamicRequest parameter addition. As a result, the parameters could not be used and links redirected user back to the /blogs/view page.

Fix: If portlet is non-instanceable and portletNamespace contains "INSTANCE_0_" while parameter does not, inject "INSTANCE_0_" into the parameter name. 