### PR TITLE
[TS] LPS-103270 Add validation for asset tag configuration

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/configuration/AssetAutoTaggerSystemConfiguration.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/configuration/AssetAutoTaggerSystemConfiguration.java
@@ -40,7 +40,8 @@ public interface AssetAutoTaggerSystemConfiguration {
 	 */
 	@Meta.AD(
 		description = "maximum-number-of-tags-per-asset-description",
-		name = "maximum-number-of-tags-per-asset", required = false
+		max = "100", min = "0", name = "maximum-number-of-tags-per-asset",
+		required = false
 	)
 	public int maximumNumberOfTagsPerAsset();
 

--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/configuration/persistence/listener/AssetAutoTaggerSystemConfigurationModelListener.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/configuration/persistence/listener/AssetAutoTaggerSystemConfigurationModelListener.java
@@ -14,12 +14,10 @@
 
 package com.liferay.asset.auto.tagger.internal.configuration.persistence.listener;
 
-import com.liferay.asset.auto.tagger.configuration.AssetAutoTaggerConfiguration;
-import com.liferay.asset.auto.tagger.configuration.AssetAutoTaggerConfigurationFactory;
-import com.liferay.asset.auto.tagger.internal.configuration.AssetAutoTaggerCompanyConfiguration;
+import com.liferay.asset.auto.tagger.internal.configuration.AssetAutoTaggerSystemConfiguration;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
 import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
@@ -27,55 +25,45 @@ import java.util.Dictionary;
 import java.util.ResourceBundle;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
+ * @author Katie Nesterovich
  */
 @Component(
 	immediate = true,
-	property = {
-		"model.class.name=com.liferay.asset.auto.tagger.internal.configuration.AssetAutoTaggerCompanyConfiguration",
-		"model.class.name=com.liferay.asset.auto.tagger.internal.configuration.AssetAutoTaggerCompanyConfiguration.scoped"
-	},
+	property = "model.class.name=com.liferay.asset.auto.tagger.internal.configuration.AssetAutoTaggerSystemConfiguration",
 	service = ConfigurationModelListener.class
 )
-public class AssetAutoTaggerCompanyConfigurationModelListener
+public class AssetAutoTaggerSystemConfigurationModelListener
 	implements ConfigurationModelListener {
 
 	@Override
 	public void onBeforeSave(String pid, Dictionary<String, Object> properties)
 		throws ConfigurationModelListenerException {
 
-		int maximumNumberOfTagsPerAsset = GetterUtil.getInteger(
-			properties.get("maximumNumberOfTagsPerAsset"));
+		AssetAutoTaggerSystemConfiguration assetAutoTaggerSystemConfiguration =
+			ConfigurableUtil.createConfigurable(
+				AssetAutoTaggerSystemConfiguration.class, properties);
 
-		AssetAutoTaggerConfiguration systemAssetAutoTaggerConfiguration =
-			_assetAutoTaggerConfigurationFactory.
-				getSystemAssetAutoTaggerConfiguration();
-
-		int systemMaximumNumberOfTagsPerAsset =
-			systemAssetAutoTaggerConfiguration.getMaximumNumberOfTagsPerAsset();
+		int maximumNumberOfTagsPerAsset =
+			assetAutoTaggerSystemConfiguration.maximumNumberOfTagsPerAsset();
 
 		if (maximumNumberOfTagsPerAsset < 0) {
 			throw new ConfigurationModelListenerException(
 				ResourceBundleUtil.getString(
 					_getResourceBundle(),
 					"maximum-number-of-tags-per-asset-cannot-be-negative"),
-				AssetAutoTaggerCompanyConfiguration.class, getClass(),
+				AssetAutoTaggerSystemConfiguration.class, getClass(),
 				properties);
 		}
 
-		if ((systemMaximumNumberOfTagsPerAsset != 0) &&
-			((maximumNumberOfTagsPerAsset == 0) ||
-			 (systemMaximumNumberOfTagsPerAsset <
-				 maximumNumberOfTagsPerAsset))) {
-
+		if (maximumNumberOfTagsPerAsset > 100) {
 			throw new ConfigurationModelListenerException(
 				ResourceBundleUtil.getString(
 					_getResourceBundle(),
-					"maximum-number-of-tags-per-asset-invalid"),
-				AssetAutoTaggerCompanyConfiguration.class, getClass(),
+					"maximum-number-of-tags-per-asset-cannot-be-greater-than-100"),
+				AssetAutoTaggerSystemConfiguration.class, getClass(),
 				properties);
 		}
 	}
@@ -84,9 +72,5 @@ public class AssetAutoTaggerCompanyConfigurationModelListener
 		return ResourceBundleUtil.getBundle(
 			LocaleThreadLocal.getThemeDisplayLocale(), getClass());
 	}
-
-	@Reference
-	private AssetAutoTaggerConfigurationFactory
-		_assetAutoTaggerConfigurationFactory;
 
 }

--- a/modules/apps/asset/asset-auto-tagger-service/src/main/resources/content/Language.properties
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/resources/content/Language.properties
@@ -3,5 +3,7 @@ asset-auto-tagger-configuration-name=Asset Auto Tagging
 asset-auto-tagger-group-configuration-name=Site Asset Auto Tagging
 enabled=Enable Auto Tagging of Assets
 maximum-number-of-tags-per-asset=Maximum Number of Tags
+maximum-number-of-tags-per-asset-cannot-be-greater-than-100=Maximum number of tags cannot be greater than 100.
+maximum-number-of-tags-per-asset-cannot-be-negative=Maximum number of tags cannot be negative.
 maximum-number-of-tags-per-asset-description=Set the maximum number of tags that will be automatically added to a single asset. Set to 0 if there is no limit.
 maximum-number-of-tags-per-asset-invalid=Maximum number of tags cannot be greater than the maximum number of system tags.


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-103270 

| Input Type | Previous behavior | Current Behavior |
| ------------- | ------------- | ------------- |
| Negative values  | Negative values could be set   | No negative values allowed  |
| Large Values  | Values over 2,147,483,647 caused integer overflow and set the value to 0 | No value over 100 (arbitrary, should be changed) | 
| Text | Strings caused values to be set to 0 | No change - alphanumeric verification for configurations is missing portal-wide, not an asset-tag specific fix |