### PR TITLE
[TS] LPS-103483 Edit article UI is disabled when using custom structure

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -220,6 +220,10 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 			ddmFormField.getDDMFormFieldOptions();
 
 		for (String value : ddmFormFieldOptions.getOptionsValues()) {
+			if (value.equals(StringPool.BLANK)) {
+				continue;
+			}
+
 			LocalizedValue label = ddmFormFieldOptions.getOptionLabels(value);
 
 			addDDMFormFieldOptionHTML(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-103483

Caused by https://issues.liferay.com/browse/LPS-101544, https://github.com/brianchandotcom/liferay-portal/pull/78840/commits/77e862ee7a83b3c8e0a6315b4fc04ad157f573ee# . 

SelectField provides an empty value by default, so `instance.getInputNode().all("option")` contained 2 empty values while `instance._getOptions()` contained only 1 (when user added an empty option). This mismatch in array sizes caused `TypeError: Cannot read property 'label' of undefined` (ddm_form.js line 3712) since index was out of bounds. 

Because an empty value is provided by default, this fix ignores empty user input - i.e. the extra empty value is not added to the node. 