### PR TITLE
[TS] LPS-103469 Blogs image-uploader is missing border box top

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_item_viewer.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_item_viewer.scss
@@ -41,6 +41,7 @@
 	.upload-view {
 		display: table;
 		height: 400px;
+		margin-top: 20px;
 		width: 100%;
 
 		& > div {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-103469

Added 20px top margin to the .upload-view, same as used in .main-content-body in Blog Images tab.

<img width="1389" alt="Blog Images Tab" src="https://user-images.githubusercontent.com/51712906/67429981-e4972e00-f5a6-11e9-97f3-2419e85ef80c.png">
<img width="1434" alt="Upload Images Tab" src="https://user-images.githubusercontent.com/51712906/67429990-e9f47880-f5a6-11e9-907d-c9f727013d4c.png">
