### PR TITLE
LPS-105745 Change btn.secondary background to match atlas theme

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/css/FragmentsEditorToolbar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/css/FragmentsEditorToolbar.scss
@@ -34,6 +34,7 @@
 	}
 
 	button.btn-secondary {
+		background-color: #fff;
 		color: #6b6c7e;
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-105745

Generated Theme
![image](https://user-images.githubusercontent.com/51712906/70738835-27d66900-1cdb-11ea-96d9-f967f2b7f5a8.png)

Default Theme
![image](https://user-images.githubusercontent.com/51712906/70738878-40468380-1cdb-11ea-8436-cdf04e9f09b0.png)

Changed the btn.secondary color to white - matching the atlas theme. 
Can't change the text color - will affect default theme.