### PR TITLE
LPS-115642 Fixing exception thrown when selecting web content in asset library via WCD

### DIFF
--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/GroupSelectorTag.java
@@ -134,12 +134,13 @@ public class GroupSelectorTag extends IncludeTag {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		Group group = _getGroup(themeDisplay);
+
 		String keywords = ParamUtil.getString(httpServletRequest, "keywords");
 
 		_groupsCount = groupSelectorProviderOptional.map(
 			groupSelectorProvider -> groupSelectorProvider.getGroupsCount(
-				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
-				keywords)
+				themeDisplay.getCompanyId(), group.getGroupId(), keywords)
 		).orElse(
 			0
 		);


### PR DESCRIPTION
This issue here was occurring because _getLiveGroupId method was throwing an exception checking whether the user has permission to view the group id being passed. DepotGroupItemSelectorProvider->getGroupsCount was catching the exception. The exception doesn't occur until the last step in the reproduction gets passes twice. The reason for this is, the first time, the scopeGroupId is associated with the Liferay site by default and the site admin user has permission to view the liferay site. But when the Asset Library is selected, the scopeGroupId is updated to the asset library group id. Therefore, the second time the user clicks on an asset library _getLiveGroupId throws an exception because the user doesn't have direct permissions to view the asset library. 
To solve this issue, instead of using the scopeGroupId that is accessed from the ThemeDisplay object to pass the group id to getGroupsCount, I created a group object in GroupSelectorTag->_getGroupsCount that holds the site group id and passed that into getGroupsCount.