### PR TITLE
LPS-117316 Fixing NullPointerException when editing content when embedding a portlet with web content

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FormNavigatorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FormNavigatorTag.java
@@ -160,7 +160,7 @@ public class FormNavigatorTag extends IncludeTag {
 		for (String categoryKey : FormNavigatorCategoryUtil.getKeys(_id)) {
 			List<FormNavigatorEntry<Object>> formNavigatorEntries =
 				FormNavigatorEntryUtil.getFormNavigatorEntries(
-					_id, categoryKey, themeDisplay.getUser(), _formModelBean);
+					_id, categoryKey, themeDisplay, _formModelBean);
 
 			if (ListUtil.isNotEmpty(formNavigatorEntries)) {
 				categoryKeys.add(categoryKey);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/BaseJournalFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/BaseJournalFormNavigatorEntry.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.taglib.ui.BaseJSPFormNavigatorEntry;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorConstants;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 
 import java.util.Locale;
@@ -57,6 +58,25 @@ public abstract class BaseJournalFormNavigatorEntry
 			ServiceContextThreadLocal.getServiceContext();
 
 		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		PortletRequest portletRequest =
+			(PortletRequest)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_REQUEST);
+
+		long classNameId = BeanParamUtil.getLong(
+			article, portletRequest, "classNameId");
+
+		if (classNameId > JournalArticleConstants.CLASS_NAME_ID_DEFAULT) {
+			return true;
+		}
+
+		return false;
+	}
+
+	protected boolean isEditDefaultValues(
+		ThemeDisplay themeDisplay, JournalArticle article) {
+
+		HttpServletRequest httpServletRequest = themeDisplay.getRequest();
 
 		PortletRequest portletRequest =
 			(PortletRequest)httpServletRequest.getAttribute(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/JournalFriendlyURLFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/ui/JournalFriendlyURLFormNavigatorEntry.java
@@ -17,6 +17,7 @@ package com.liferay.journal.web.internal.servlet.taglib.ui;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.servlet.taglib.ui.FormNavigatorEntry;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 import javax.servlet.ServletContext;
 
@@ -36,6 +37,17 @@ public class JournalFriendlyURLFormNavigatorEntry
 	@Override
 	public String getKey() {
 		return "friendly-url";
+	}
+
+	@Override
+	public boolean isVisible(
+		ThemeDisplay themeDisplay, JournalArticle article) {
+
+		if (isEditDefaultValues(themeDisplay, article)) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/BaseFormNavigatorEntry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/BaseFormNavigatorEntry.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.servlet.taglib.ui;
 
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 import java.io.IOException;
 
@@ -46,6 +47,11 @@ public abstract class BaseFormNavigatorEntry<T>
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException;
+
+	@Override
+	public boolean isVisible(ThemeDisplay themeDisplay, T formModelBean) {
+		return true;
+	}
 
 	@Override
 	public boolean isVisible(User user, T formModelBean) {

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntry.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.servlet.taglib.ui;
 
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 import java.io.IOException;
 
@@ -88,6 +89,18 @@ public interface FormNavigatorEntry<T> {
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException;
+
+	/**
+	 * Returns <code>true</code> if the form navigator entry should be
+	 * displayed.
+	 *
+	 * @param  themeDisplay the current theme display
+	 * @param  formModelBean the bean edited by the form navigator, or
+	 *         <code>null</code>
+	 * @return <code>true</code> if the form navigator entry should be
+	 *         displayed; <code>false</code> otherwise
+	 */
+	public boolean isVisible(ThemeDisplay themeDisplay, T formModelBean);
 
 	/**
 	 * Returns <code>true</code> if the form navigator entry should be

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntryUtil.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.servlet.taglib.ui;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -37,6 +38,18 @@ import java.util.Optional;
  * @author Sergio González
  */
 public class FormNavigatorEntryUtil {
+
+	public static <T> List<FormNavigatorEntry<T>> getFormNavigatorEntries(
+		String formNavigatorId, String categoryKey, ThemeDisplay themeDisplay,
+		T formModelBean) {
+
+		List<FormNavigatorEntry<T>> formNavigatorEntries =
+			_getFormNavigatorEntries(
+				formNavigatorId, categoryKey, formModelBean);
+
+		return filterVisibleFormNavigatorEntries(
+			formNavigatorEntries, themeDisplay, formModelBean);
+	}
 
 	public static <T> List<FormNavigatorEntry<T>> getFormNavigatorEntries(
 		String formNavigatorId, String categoryKey, User user,
@@ -112,6 +125,23 @@ public class FormNavigatorEntryUtil {
 		}
 
 		return labels.toArray(new String[0]);
+	}
+
+	protected static <T> List<FormNavigatorEntry<T>>
+		filterVisibleFormNavigatorEntries(
+			List<FormNavigatorEntry<T>> formNavigatorEntries,
+			ThemeDisplay themeDisplay, T formModelBean) {
+
+		List<FormNavigatorEntry<T>> filteredFormNavigatorEntries =
+			new ArrayList<>();
+
+		for (FormNavigatorEntry<T> formNavigatorEntry : formNavigatorEntries) {
+			if (formNavigatorEntry.isVisible(themeDisplay, formModelBean)) {
+				filteredFormNavigatorEntries.add(formNavigatorEntry);
+			}
+		}
+
+		return filteredFormNavigatorEntries;
 	}
 
 	protected static <T> List<FormNavigatorEntry<T>>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-117376

The issue here was caused by the the changes made in LPS-106268. The attribute, javax.portlet.request, for the HttpServletRequest object was getting overwritten to null. This caused the porteletRequest object in BaseJournalFormNavigatorEntry -> isEditDefaultValues to be assigned to null when trying to get the javax.portlet.request attribute. Therefore, a NullPointerException was being thrown in ParamUtil -> get when trying to access a parameter of porteletRequest.

To fix the issue, I found that the HttpServletRequest was being stored in the themeDisplay before getting overwritten. I overloaded a few methods to pass the themeDisplay object as a parameter so the portletRequest can be assigned with the correct value stored in the themeDisplay.
