### PR TITLE
LPS-118134 Added file extension to image's temp file name

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -366,6 +366,7 @@ public class JournalArticleModelValidator
 		String smallImageURL = article.getSmallImageURL();
 
 		byte[] smallImageBytes = null;
+		String smallImageExtension = null;
 		File smallImageFile = null;
 
 		if (smallImage) {
@@ -374,9 +375,11 @@ public class JournalArticleModelValidator
 
 			if (image != null) {
 				smallImageBytes = image.getTextObj();
+				smallImageExtension = image.getType();
 
 				try {
-					smallImageFile = FileUtil.createTempFile(smallImageBytes);
+					smallImageFile = FileUtil.createTempFile(
+						smallImageBytes, smallImageExtension);
 				}
 				catch (IOException ioException) {
 					smallImageBytes = null;

--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -255,6 +255,17 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 	}
 
 	@Override
+	public File createTempFile(byte[] bytes, String extension)
+		throws IOException {
+
+		File file = createTempFile(extension);
+
+		write(file, bytes, false);
+
+		return file;
+	}
+
+	@Override
 	public File createTempFile(InputStream inputStream) throws IOException {
 		File file = createTempFile(StringPool.BLANK);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/File.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/File.java
@@ -54,6 +54,9 @@ public interface File {
 
 	public java.io.File createTempFile(byte[] bytes) throws IOException;
 
+	public java.io.File createTempFile(byte[] bytes, String extension)
+		throws IOException;
+
 	public java.io.File createTempFile(InputStream inputStream)
 		throws IOException;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FileUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FileUtil.java
@@ -84,6 +84,12 @@ public class FileUtil {
 		return getFile().createTempFile(bytes);
 	}
 
+	public static File createTempFile(byte[] bytes, String extension)
+		throws IOException {
+
+		return getFile().createTempFile(bytes, extension);
+	}
+
 	public static File createTempFile(InputStream inputStream)
 		throws IOException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.6.0
+version 11.0.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/settings/MockFile.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/settings/MockFile.java
@@ -74,6 +74,11 @@ public class MockFile implements com.liferay.portal.kernel.util.File {
 	}
 
 	@Override
+	public File createTempFile(byte[] bytes, String extension) {
+		return null;
+	}
+
+	@Override
 	public File createTempFile(InputStream inputStream) {
 		return null;
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-118134

The issue here was occurring because validateModel in JournalArticleModelValidator was creating a temp file name for the featured image attached to the article and when that image was getting validated on allowed file extensions it was returning an error because the file extension was not added to the temp file name.
To fix this bug, I overloaded FileUtil.createTempFile to pass in the featured image's file extension so that the temp file name has the extension added at the end.