### PR TITLE
LPS-118136 Fixing model validator to correctly handle featured image and its exception errors

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -206,7 +206,12 @@ public class JournalArticleModelValidator
 		}
 
 		if (!validSmallImageExtension) {
-			throw new ArticleSmallImageNameException(smallImageName);
+			String smallImageExtension = smallImageName.substring(
+				smallImageName.indexOf(".") + 1);
+
+			throw new ArticleSmallImageNameException(
+				"Extension " + smallImageExtension +
+					" is not an allowed file upload type.");
 		}
 
 		long smallImageMaxSize =
@@ -366,6 +371,7 @@ public class JournalArticleModelValidator
 		String smallImageURL = article.getSmallImageURL();
 
 		byte[] smallImageBytes = null;
+		String smallImageExtension = null;
 		File smallImageFile = null;
 
 		if (smallImage) {
@@ -374,9 +380,15 @@ public class JournalArticleModelValidator
 
 			if (image != null) {
 				smallImageBytes = image.getTextObj();
+				smallImageExtension = image.getType();
 
 				try {
-					smallImageFile = FileUtil.createTempFile(smallImageBytes);
+					if (smallImageBytes != null) {
+						smallImageFile = FileUtil.createTempFile(
+							smallImageExtension);
+
+						FileUtil.write(smallImageFile, smallImageBytes, false);
+					}
 				}
 				catch (IOException ioException) {
 					smallImageBytes = null;
@@ -481,8 +493,9 @@ public class JournalArticleModelValidator
 
 			Image image = _imageLocalService.fetchImage(smallImageId);
 
-			if (image == null) {
-				throw new NoSuchImageException();
+			if ((image == null) || (smallImageBytes == null)) {
+				throw new NoSuchImageException(
+					"The featured image was not found");
 			}
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-118134
https://issues.liferay.com/browse/LPS-118136

The issues here were the following:

1. validateModel in JournalArticleModelValidator was creating a temp file name for the featured image attached to the article and when that image was getting validated on allowed file extensions it was returning an error because the file extension was not added to the temp file name. To fix this bug, I create smallImageFile by calling FileUtil.createTempFile(String extension) instead of FileUtil.createTempFile(bytes[] bytes). This creates an empty file with the image's extension added to the name. Then I write out the image to the file.
2. When the image is deleted and modelValidate creates a temp file for the image, it tries to write out smallImageBytes but this is a null value. This results in a file exception error to occur and the model validator does not catch this exception. I fixed this by adding a condition before creating the temp file that smallImageBytes not be equal to null and also adding a check whether smallImageBytes is null in validateReferences() before throwing a NoSuchImageException.
3. The script was not sending descriptive exception error messages. I added two messages; one in validateReferences() for when the image does not exist, and one in validate() for when the file extension is not valid.