### PR TITLE
LPS-119216 Add web content author info to edit workflow task

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
@@ -257,6 +257,16 @@ renderResponse.setTitle(headerTitle);
 							assetRenderer="<%= assetRenderer %>"
 							template="<%= AssetRenderer.TEMPLATE_ABSTRACT %>"
 						/>
+
+						<%
+						String[] metadataFields = {"author", "categories", "tags"};
+						%>
+
+						<liferay-asset:asset-metadata
+							className="<%= assetEntry.getClassName() %>"
+							classPK="<%= assetEntry.getClassPK() %>"
+							metadataFields="<%= metadataFields %>"
+						/>
 					</liferay-ui:panel>
 
 					<c:if test="<%= assetEntry != null %>">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-119216

Author of web content was removed from the edit workflow task page in [LPS-61400](https://issues.liferay.com/browse/LPS-61400).
I added the info back and changed the tag from `<liferay-ui:asset-metadata>` to `<liferay-asset:asset-metadata>`