### PR TITLE
LPS-118602 Fetch DlFileEntry Metadata by D_F instead of file entry id

### DIFF
--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 5.14.3
+Bundle-Version: 5.14.4
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1655,14 +1655,19 @@ public class DLFileEntryLocalServiceImpl
 			(dlFileEntry.getFileEntryTypeId() !=
 				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT)) {
 
-			DLFileEntryMetadata dlFileEntryMetadata =
-				dlFileEntryMetadataPersistence.fetchByFileEntryId_Last(
-					fileEntryId, null);
-
 			DDMStructure ddmStructure = DDMStructureManagerUtil.fetchStructure(
-				dlFileEntryMetadata.getDDMStructureId());
+				dlFileEntry.getGroupId(),
+				classNameLocalService.getClassNameId(DLFileEntryMetadata.class),
+				DLUtil.getDDMStructureKey(dlFileEntry.getDLFileEntryType()));
 
 			if (ddmStructure != null) {
+				DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+				DLFileEntryMetadata dlFileEntryMetadata =
+					dlFileEntryMetadataPersistence.fetchByD_F(
+						ddmStructure.getStructureId(),
+						dlFileVersion.getFileVersionId());
+
 				DDMStructureLinkManagerUtil.deleteStructureLink(
 					classNameLocalService.getClassNameId(
 						DLFileEntryMetadata.class),


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-118602

A regression bug was found while testing on 7.2.x. When a file is uploaded to a new document, two file entry metadata rows are created in the database. The order in which these entries are created differ from 7.2.x and Master. When fetching the metadata using fetchByFileEntryId_Last, the wrong metadata was retrieved in 7.2.x.
To solve the issue, I changed the fetch method for the metadata to fetchByD_F. I also needed to bring back the change made to the creation of the ddmstructure in the SF commit and change the position of the declaration to be able to use it in the fetch method.