### PR TITLE
LPS-122137 Fix message board redirect

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
@@ -284,6 +284,22 @@ public class EditMessageMVCActionCommand extends BaseMVCActionCommand {
 				actionRequest, actionResponse, message);
 		}
 
+		LiferayActionResponse liferayActionResponse =
+			(LiferayActionResponse)actionResponse;
+
+		PortletURL portletURL = liferayActionResponse.createRenderURL();
+
+		String url = portletURL.toString();
+
+		if (url.contains("/web/guest")) {
+			portletURL.setParameter(
+				"mvcRenderCommandName", "/message_boards/view_message");
+			portletURL.setParameter(
+				"messageId", String.valueOf(message.getMessageId()));
+
+			return portletURL.toString();
+		}
+
 		return ParamUtil.getString(actionRequest, "redirect");
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122137

The issue here was that, after publishing a thread, the user was redirected to the threads list instead of the published message.
To fix the issue, I added a condition that will redirect the user to the published thread when the thread is edited from a message board widget 