### PR TITLE
LPS-122137 Fix redirect for message boards

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
@@ -284,7 +284,24 @@ public class EditMessageMVCActionCommand extends BaseMVCActionCommand {
 				actionRequest, actionResponse, message);
 		}
 
-		return ParamUtil.getString(actionRequest, "redirect");
+		String portletResource = ParamUtil.getString(
+			actionRequest, "portletResource");
+
+		if (Validator.isNotNull(portletResource)) {
+			return ParamUtil.getString(actionRequest, "redirect");
+		}
+
+		LiferayActionResponse liferayActionResponse =
+			(LiferayActionResponse)actionResponse;
+
+		PortletURL portletURL = liferayActionResponse.createRenderURL();
+
+		portletURL.setParameter(
+			"mvcRenderCommandName", "/message_boards/view_message");
+		portletURL.setParameter(
+			"messageId", String.valueOf(message.getMessageId()));
+
+		return portletURL.toString();
 	}
 
 	protected String getSaveAndContinueRedirect(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122137

Fixing regression caused by [LPS-121301](https://issues.liferay.com/browse/LPS-121301)
When accessing the edit message page from an Asset Publisher, get the redirect from the actionRequest. Otherwise, redirect back to the edited message.