### PR TITLE
LPS-130127 Check that asset category matches with vocabulary

### DIFF
--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/CustomUserAttributesAssetEntryQueryProcessor.java
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/CustomUserAttributesAssetEntryQueryProcessor.java
@@ -15,7 +15,9 @@
 package com.liferay.asset.entry.query.processor.custom.user.attributes.internal;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.util.AssetEntryQueryProcessor;
@@ -98,7 +100,15 @@ public class CustomUserAttributesAssetEntryQueryProcessor
 					new String[0], QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 			for (AssetCategory assetCategory : assetCategories) {
-				allCategoryIdsList.add(assetCategory.getCategoryId());
+				AssetVocabulary assetVocabulary =
+					_assetVocabularyLocalService.fetchAssetVocabulary(
+						assetCategory.getVocabularyId());
+
+				String vocabularyTitle = assetVocabulary.getTitleCurrentValue();
+
+				if (vocabularyTitle.equals(customUserAttributeName)) {
+					allCategoryIdsList.add(assetCategory.getCategoryId());
+				}
 			}
 		}
 
@@ -107,6 +117,9 @@ public class CustomUserAttributesAssetEntryQueryProcessor
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130127

The issue here is that asset publisher can be filtered by a custom user category that doesn't exist when that category exists under a different vocabulary.
I fixed this issue by adding a condition to check the vocabulary of the asset category matches that of the user attribute being filtered by. The asset category will only be added to the search query when true.

**NOTE/INQUIRY:** this fix will result in the behavior acting as if the the custom attribute field is empty. It will not filter the asset entries and will return all results. Is this what the expected behavior for asset publisher should be? Or should the results returned be NONE?
Please confirm this for me.