### PR TITLE
COMMERCE-9152 - When we try to add a new default payment method we should see only the active ones

### DIFF
--- a/modules/apps/commerce/commerce-payment-web/src/main/java/com/liferay/commerce/payment/web/internal/dao/search/AccountEntryCommercePaymentMethodDisplaySearchContainerFactory.java
+++ b/modules/apps/commerce/commerce-payment-web/src/main/java/com/liferay/commerce/payment/web/internal/dao/search/AccountEntryCommercePaymentMethodDisplaySearchContainerFactory.java
@@ -17,7 +17,10 @@ package com.liferay.commerce.payment.web.internal.dao.search;
 import com.liferay.account.constants.AccountPortletKeys;
 import com.liferay.commerce.payment.method.CommercePaymentMethod;
 import com.liferay.commerce.payment.method.CommercePaymentMethodRegistry;
+import com.liferay.commerce.payment.model.CommercePaymentMethodGroupRel;
+import com.liferay.commerce.payment.service.CommercePaymentMethodGroupRelServiceUtil;
 import com.liferay.commerce.payment.web.internal.display.CommercePaymentMethodDisplay;
+import com.liferay.commerce.product.service.CommerceChannelLocalServiceUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -62,11 +65,31 @@ public class AccountEntryCommercePaymentMethodDisplaySearchContainerFactory {
 		Map<String, CommercePaymentMethod> commercePaymentMethods =
 			commercePaymentMethodRegistry.getCommercePaymentMethods();
 
+		long commerceChannelGroupId =
+			CommerceChannelLocalServiceUtil.
+				getCommerceChannelGroupIdBySiteGroupId(
+					themeDisplay.getScopeGroupId());
+
 		searchContainer.setResultsAndTotal(
 			() -> TransformUtil.transform(
 				commercePaymentMethods.values(),
-				commercePaymentMethod -> new CommercePaymentMethodDisplay(
-					commercePaymentMethod, themeDisplay.getLocale())),
+				commercePaymentMethod -> {
+					CommercePaymentMethodGroupRel
+						commercePaymentMethodGroupRel =
+							CommercePaymentMethodGroupRelServiceUtil.
+								fetchCommercePaymentMethodGroupRel(
+									commerceChannelGroupId,
+									commercePaymentMethod.getKey());
+
+					if ((commercePaymentMethodGroupRel != null) &&
+						commercePaymentMethodGroupRel.isActive()) {
+
+						return new CommercePaymentMethodDisplay(
+							commercePaymentMethod, themeDisplay.getLocale());
+					}
+
+					return null;
+				}),
 			commercePaymentMethods.size());
 
 		searchContainer.setRowChecker(


### PR DESCRIPTION
When choosing an account default payment method, all the options were being showed, instead of only the active payment methods.
Proposed fix is to add a check to see if each payment method is active before showing it as an option for an account default payment method.