### PR TITLE
COMMERCE-10164 - In the Payment/Shipping Restrictions tabs, the Countries sorting changes after a virtual instance is created

### DIFF
--- a/modules/apps/commerce/commerce-payment-web/src/main/java/com/liferay/commerce/payment/web/internal/frontend/data/set/view/table/CommercePaymentRestrictionsPageTableFDSView.java
+++ b/modules/apps/commerce/commerce-payment-web/src/main/java/com/liferay/commerce/payment/web/internal/frontend/data/set/view/table/CommercePaymentRestrictionsPageTableFDSView.java
@@ -28,7 +28,6 @@ import com.liferay.frontend.data.set.provider.search.FDSKeywords;
 import com.liferay.frontend.data.set.provider.search.FDSPagination;
 import com.liferay.frontend.data.set.view.FDSView;
 import com.liferay.frontend.data.set.view.table.selectable.BaseSelectableTableFDSView;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanProperties;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -104,7 +103,7 @@ public class CommercePaymentRestrictionsPageTableFDSView
 					commerceChannel.getGroupId(), true);
 
 		String orderByFieldName = _beanProperties.getString(
-			sort, "fieldName", StringPool.BLANK);
+			sort, "fieldName", "name");
 
 		String orderByType = "asc";
 


### PR DESCRIPTION
Country names were being ordered wrong in the payment restrictions page when creating a new virtual instance.
Proposed fix is to make the order be by name ascending by default.