### PR TITLE
COMMERCE-9798 - Subscription type is missing from the subscription length

### DIFF
--- a/modules/apps/commerce/commerce-subscription-web/src/main/java/com/liferay/commerce/subscription/web/internal/display/context/BaseCPDefinitionSubscriptionInfoDisplayContext.java
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/java/com/liferay/commerce/subscription/web/internal/display/context/BaseCPDefinitionSubscriptionInfoDisplayContext.java
@@ -45,6 +45,10 @@ public class BaseCPDefinitionSubscriptionInfoDisplayContext
 	}
 
 	public CPSubscriptionType getCPSubscriptionType(String subscriptionType) {
+		if (subscriptionType.isEmpty()) {
+			return getCPSubscriptionTypes().get(0);
+		}
+
 		return _cpSubscriptionTypeRegistry.getCPSubscriptionType(
 			subscriptionType);
 	}


### PR DESCRIPTION
This bug is occurring because the subscriptionType is being passed empty in [getCPSubscriptionType](https://github.com/liferay/liferay-portal/blob/ffaf63c35bea589c743101c834914c4829f43ef5/modules/apps/commerce/commerce-subscription-web/src/main/java/com/liferay/commerce/subscription/web/internal/display/context/BaseCPDefinitionSubscriptionInfoDisplayContext.java#L47)()
The proposed fix is to add a structure to check if the subscriptionType is empty, and if so, return the first item in [cpSubscriptionTypes](https://github.com/liferay/liferay-portal/blob/ffaf63c35bea589c743101c834914c4829f43ef5/modules/apps/commerce/commerce-subscription-web/src/main/java/com/liferay/commerce/subscription/web/internal/display/context/BaseCPDefinitionSubscriptionInfoDisplayContext.java#L59)()

Related ticket: [COMMERCE-9798](https://issues.liferay.com/browse/COMMERCE-9798)