### PR TITLE
COMMERCE-10279 - Higher promotions price show up in summary checkout over lower price list

### DIFF
--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/order_summary.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/order_summary.jsp
@@ -185,7 +185,7 @@ Map<Long, List<CommerceOrderValidatorResult>> commerceOrderValidatorResultsMap =
 								<div class="value-section">
 									<span class="price">
 										<c:choose>
-											<c:when test="<%= !unitPromoPriceCommerceMoney.isEmpty() && CommerceBigDecimalUtil.gt(unitPromoPriceCommerceMoney.getPrice(), BigDecimal.ZERO) %>">
+											<c:when test="<%= !unitPromoPriceCommerceMoney.isEmpty() && CommerceBigDecimalUtil.gt(unitPromoPriceCommerceMoney.getPrice(), BigDecimal.ZERO) && CommerceBigDecimalUtil.lt(unitPromoPriceCommerceMoney.getPrice(), unitPriceCommerceMoney.getPrice()) %>">
 												<span class="price-value price-value-promo">
 													<%= HtmlUtil.escape(unitPromoPriceCommerceMoney.format(locale)) %>
 												</span>


### PR DESCRIPTION
Related Issue: [COMMERCE-10279](https://issues.liferay.com/browse/COMMERCE-10279)

Problem was that the discount price was being showed even if it was higher than the base price.
Proposed fix is to only show the discount price if it is lower than the base price