### PR TITLE
COMMERCE-10249 - UI issues for the printing of an Pending Order

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/CommerceOpenOrderContentPortlet.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/CommerceOpenOrderContentPortlet.java
@@ -71,6 +71,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-commerce-open-order-content",
 		"com.liferay.portlet.display-category=commerce",
+		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.instanceable=false",
 		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/CommerceOrderContentPortlet.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/CommerceOrderContentPortlet.java
@@ -62,6 +62,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-commerce-order-content",
 		"com.liferay.portlet.display-category=commerce",
+		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.instanceable=false",
 		"com.liferay.portlet.layout-cacheable=true",
 		"com.liferay.portlet.preferences-owned-by-group=true",

--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,0 +1,5 @@
+.dropdown-item {
+	.c-inner {
+		display: inline;
+	}
+}

--- a/modules/apps/commerce/commerce-report-impl/src/main/resources/com/liferay/commerce/report/internal/exporter/dependencies/commerce_order.jrxml
+++ b/modules/apps/commerce/commerce-report-impl/src/main/resources/com/liferay/commerce/report/internal/exporter/dependencies/commerce_order.jrxml
@@ -444,7 +444,7 @@
 				<text><![CDATA[External Reference Code]]></text>
 			</staticText>
 			<textField isBlankWhenNull="true">
-				<reportElement height="14" uuid="752f0505-9393-4c74-bb26-99d7ff2af666" width="167" x="354" y="150">
+				<reportElement height="14" uuid="752f0505-9393-4c74-bb26-99d7ff2af666" width="185" x="354" y="150">
 					<property name="com.jaspersoft.studio.unit.height" value="px" />
 					<property name="com.jaspersoft.studio.unit.width" value="px" />
 				</reportElement>


### PR DESCRIPTION
Related Issue: [COMMERCE-10249](https://issues.liferay.com/browse/COMMERCE-10249)

The Print icon was misplaced because of a wrong display setting
Proposed fix is to change the display type of the icon. I also applied the change to the Placed Orders page because it had the same bug.

The ERC was being truncated because the width for the ERC field in the template was too small to fit a standard ERC.
Proposed fix is to increase the ERC field width to 185 which is the standard ERC size.

The print page output pdf doesn't have a localized title because there isn't any implementation to change the default title.
The fix would be to find a way to change the default title to a dynamic variable, but there doesn't seem to be a way to do so.
The title is able to be changed using `<property name="net.sf.jasperreports.export.pdf.metadata.title" value="test" />`, however, it doesn't accept dynamic values.
