### PR TITLE
COMMERCE-10173 - It's possible to save a product configuration with wrong values

### DIFF
--- a/modules/apps/commerce/commerce-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce API
 Bundle-SymbolicName: com.liferay.commerce.api
-Bundle-Version: 58.0.1
+Bundle-Version: 58.1.0
 Export-Package:\
 	com.liferay.commerce.address,\
 	com.liferay.commerce.checkout.helper,\

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/CommerceOrderQuantityException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/CommerceOrderQuantityException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class CommerceOrderQuantityException extends PortalException {
+
+	public CommerceOrderQuantityException() {
+	}
+
+	public CommerceOrderQuantityException(String msg) {
+		super(msg);
+	}
+
+	public CommerceOrderQuantityException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public CommerceOrderQuantityException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_configuration.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_configuration.jsp
@@ -110,6 +110,7 @@ boolean shippable = BeanParamUtil.getBoolean(cpDefinition, request, "shippable",
 
 						<aui:input name="minOrderQuantity" value="<%= (cpDefinitionInventory == null) ? String.valueOf(CPDefinitionInventoryConstants.DEFAULT_MIN_ORDER_QUANTITY) : String.valueOf(cpDefinitionInventory.getMinOrderQuantity()) %>">
 							<aui:validator name="digits" />
+							<aui:validator name="required" />
 							<aui:validator name="min">1</aui:validator>
 						</aui:input>
 
@@ -143,11 +144,13 @@ boolean shippable = BeanParamUtil.getBoolean(cpDefinition, request, "shippable",
 
 						<aui:input name="maxOrderQuantity" value="<%= (cpDefinitionInventory == null) ? String.valueOf(CPDefinitionInventoryConstants.DEFAULT_MAX_ORDER_QUANTITY) : String.valueOf(cpDefinitionInventory.getMaxOrderQuantity()) %>">
 							<aui:validator name="digits" />
+							<aui:validator name="required" />
 							<aui:validator name="min">1</aui:validator>
 						</aui:input>
 
 						<aui:input name="multipleOrderQuantity" value="<%= (cpDefinitionInventory == null) ? String.valueOf(CPDefinitionInventoryConstants.DEFAULT_MULTIPLE_ORDER_QUANTITY) : String.valueOf(cpDefinitionInventory.getMultipleOrderQuantity()) %>">
 							<aui:validator name="digits" />
+							<aui:validator name="required" />
 							<aui:validator name="min">1</aui:validator>
 						</aui:input>
 					</div>

--- a/modules/apps/commerce/commerce-service/service.xml
+++ b/modules/apps/commerce/commerce-service/service.xml
@@ -931,6 +931,7 @@
 		<exception>CommerceOrderPaymentMethod</exception>
 		<exception>CommerceOrderPrice</exception>
 		<exception>CommerceOrderPurchaseOrderNumber</exception>
+		<exception>CommerceOrderQuantity</exception>
 		<exception>CommerceOrderRequestedDeliveryDate</exception>
 		<exception>CommerceOrderShippingAddress</exception>
 		<exception>CommerceOrderShippingMethod</exception>

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CPDefinitionInventoryLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CPDefinitionInventoryLocalServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.commerce.service.impl;
 
+import com.liferay.commerce.exception.CommerceOrderQuantityException;
 import com.liferay.commerce.model.CPDefinitionInventory;
 import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
@@ -65,6 +66,9 @@ public class CPDefinitionInventoryLocalServiceImpl
 			cpDefinition = _cpDefinitionLocalService.copyCPDefinition(
 				cpDefinitionId);
 		}
+
+		_validateOrderQuantity(
+			minOrderQuantity, maxOrderQuantity, multipleOrderQuantity);
 
 		cpDefinitionInventory.setGroupId(cpDefinition.getGroupId());
 		cpDefinitionInventory.setCompanyId(user.getCompanyId());
@@ -194,6 +198,9 @@ public class CPDefinitionInventoryLocalServiceImpl
 					newCPDefinition.getCPDefinitionId());
 		}
 
+		_validateOrderQuantity(
+			minOrderQuantity, maxOrderQuantity, multipleOrderQuantity);
+
 		cpDefinitionInventory.setCPDefinitionInventoryEngine(
 			cpDefinitionInventoryEngine);
 		cpDefinitionInventory.setLowStockActivity(lowStockActivity);
@@ -207,6 +214,19 @@ public class CPDefinitionInventoryLocalServiceImpl
 		cpDefinitionInventory.setMultipleOrderQuantity(multipleOrderQuantity);
 
 		return cpDefinitionInventoryPersistence.update(cpDefinitionInventory);
+	}
+
+	private void _validateOrderQuantity(
+			int minOrderQuantity, int maxOrderQuantity,
+			int multipleOrderQuantity)
+		throws CommerceOrderQuantityException {
+
+		if ((minOrderQuantity < 1) || (maxOrderQuantity < 1) ||
+			(multipleOrderQuantity < 1)) {
+
+			throw new CommerceOrderQuantityException(
+				"Order Quantity must be greater than  or equal to 1");
+		}
 	}
 
 	@Reference


### PR DESCRIPTION
Related Issue: [COMMERCE-10173](https://issues.liferay.com/browse/COMMERCE-10173)

Problem was that there was no validation of existence in the inputs.
Proposed fix is to add a required validator so that the product can't be saved with the specified inputs empty.
Also there was no validation at the backend, so this solution includes that as well.