### PR TITLE
COMMERCE-10066 - On the quantity selector, allowed quantities list is not filtered based on the product configurations(min,max,multiple)

### DIFF
--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/java/com/liferay/commerce/frontend/taglib/servlet/taglib/AddToCartTag.java
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/java/com/liferay/commerce/frontend/taglib/servlet/taglib/AddToCartTag.java
@@ -32,6 +32,7 @@ import com.liferay.commerce.util.CommerceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -85,8 +86,21 @@ public class AddToCartTag extends IncludeTag {
 
 				hasChildCPDefinitions = _cpContentHelper.hasChildCPDefinitions(
 					cpDefinitionId);
+
 				_productSettingsModel = _productHelper.getProductSettingsModel(
 					cpDefinitionId);
+
+				int multipleQuantity =
+					_productSettingsModel.getMultipleQuantity();
+
+				int[] allowedQuantities = ArrayUtil.filter(
+					_productSettingsModel.getAllowedQuantities(),
+					quantity ->
+						(quantity >= _productSettingsModel.getMinQuantity()) &&
+						(quantity <= _productSettingsModel.getMaxQuantity()) &&
+						((quantity % multipleQuantity) == 0));
+
+				_productSettingsModel.setAllowedQuantities(allowedQuantities);
 			}
 
 			String sku = null;


### PR DESCRIPTION
Related Issue: [COMMERCE-10066](https://issues.liferay.com/browse/COMMERCE-10066)

The problem was that there was no filtering being done before showing the quantity options on the product's page.
Proposed fix is to filter the existing quantity options according to the specified configurations (min, max and multiple).