### PR TITLE
COMMERCE-10761 Chekout: user can select existing address with a country that is not available for the channel

### DIFF
--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
@@ -66,6 +66,8 @@ boolean hasManageAddressesPermission = baseAddressCheckoutStepDisplayContext.has
 					boolean addressWasFound = false;
 
 					for (CommerceAddress commerceAddress : commerceAddresses) {
+						Country commerceAddressCountry = commerceAddress.getCountry();
+
 						boolean selectedAddress = commerceAddressId == commerceAddress.getCommerceAddressId();
 
 						if (selectedAddress) {
@@ -73,7 +75,9 @@ boolean hasManageAddressesPermission = baseAddressCheckoutStepDisplayContext.has
 						}
 					%>
 
-						<aui:option data-city="<%= HtmlUtil.escapeAttribute(commerceAddress.getCity()) %>" data-country="<%= HtmlUtil.escapeAttribute(String.valueOf(commerceAddress.getCountryId())) %>" data-name="<%= HtmlUtil.escapeAttribute(commerceAddress.getName()) %>" data-phone-number="<%= HtmlUtil.escapeAttribute(commerceAddress.getPhoneNumber()) %>" data-region="<%= HtmlUtil.escapeAttribute(String.valueOf(commerceAddress.getRegionId())) %>" data-street-1="<%= HtmlUtil.escapeAttribute(commerceAddress.getStreet1()) %>" data-street-2="<%= Validator.isNotNull(commerceAddress.getStreet2()) ? HtmlUtil.escapeAttribute(commerceAddress.getStreet2()) : StringPool.BLANK %>" data-street-3="<%= Validator.isNotNull(commerceAddress.getStreet3()) ? HtmlUtil.escapeAttribute(commerceAddress.getStreet3()) : StringPool.BLANK %>" data-zip="<%= HtmlUtil.escapeAttribute(commerceAddress.getZip()) %>" label="<%= HtmlUtil.escape(commerceAddress.getName()) %>" selected="<%= selectedAddress %>" value="<%= commerceAddress.getCommerceAddressId() %>" />
+						<c:if test="<%= !commerceAddressCountry.isGroupFilterEnabled() %>">
+							<aui:option data-city="<%= HtmlUtil.escapeAttribute(commerceAddress.getCity()) %>" data-country="<%= HtmlUtil.escapeAttribute(String.valueOf(commerceAddress.getCountryId())) %>" data-name="<%= HtmlUtil.escapeAttribute(commerceAddress.getName()) %>" data-phone-number="<%= HtmlUtil.escapeAttribute(commerceAddress.getPhoneNumber()) %>" data-region="<%= HtmlUtil.escapeAttribute(String.valueOf(commerceAddress.getRegionId())) %>" data-street-1="<%= HtmlUtil.escapeAttribute(commerceAddress.getStreet1()) %>" data-street-2="<%= Validator.isNotNull(commerceAddress.getStreet2()) ? HtmlUtil.escapeAttribute(commerceAddress.getStreet2()) : StringPool.BLANK %>" data-street-3="<%= Validator.isNotNull(commerceAddress.getStreet3()) ? HtmlUtil.escapeAttribute(commerceAddress.getStreet3()) : StringPool.BLANK %>" data-zip="<%= HtmlUtil.escapeAttribute(commerceAddress.getZip()) %>" label="<%= HtmlUtil.escape(commerceAddress.getName()) %>" selected="<%= selectedAddress %>" value="<%= commerceAddress.getCommerceAddressId() %>" />
+						</c:if>
 
 					<%
 					}


### PR DESCRIPTION
This issue was reproducing because there wasn't a check before adding the Addresses into the dropdown menu.
Proposed fix consists in adding a verification in the JSP file to check if the Country of the current Address has not the Group Filter enabled before adding them.

Related tickets: [LPP-47913](https://issues.liferay.com/browse/LPP-47913), [COMMERCE-10761](https://issues.liferay.com/browse/COMMERCE-10761)