### PR TITLE
COMMERCE-10759 - Checkout: can select existing address with a country for which billing/shipping is disabled

### DIFF
--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/CommerceOrderShippingAndBillingException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/CommerceOrderShippingAndBillingException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class CommerceOrderShippingAndBillingException extends PortalException {
+
+	public CommerceOrderShippingAndBillingException() {
+	}
+
+	public CommerceOrderShippingAndBillingException(String msg) {
+		super(msg);
+	}
+
+	public CommerceOrderShippingAndBillingException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public CommerceOrderShippingAndBillingException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/commerce/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/display/context/BillingAddressCheckoutStepDisplayContext.java
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/display/context/BillingAddressCheckoutStepDisplayContext.java
@@ -27,9 +27,11 @@ import com.liferay.commerce.product.service.CommerceChannelAccountEntryRelLocalS
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
 import com.liferay.commerce.service.CommerceAddressService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CountryModel;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -65,9 +67,22 @@ public class BillingAddressCheckoutStepDisplayContext
 	public List<CommerceAddress> getCommerceAddresses() throws PortalException {
 		CommerceOrder commerceOrder = getCommerceOrder();
 
-		return commerceAddressService.getBillingCommerceAddresses(
-			commerceOrder.getCompanyId(), AccountEntry.class.getName(),
-			commerceOrder.getCommerceAccountId());
+		List<CommerceAddress> addresses =
+			commerceAddressService.getBillingCommerceAddresses(
+				commerceOrder.getCompanyId(), AccountEntry.class.getName(),
+				commerceOrder.getCommerceAccountId());
+
+		List<CommerceAddress> availableAddresses = new ArrayList<>();
+
+		for (CommerceAddress address : addresses) {
+			CountryModel country = address.getCountry();
+
+			if (country.isBillingAllowed()) {
+				availableAddresses.add(address);
+			}
+		}
+
+		return availableAddresses;
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/display/context/ShippingAddressCheckoutStepDisplayContext.java
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/display/context/ShippingAddressCheckoutStepDisplayContext.java
@@ -27,9 +27,11 @@ import com.liferay.commerce.product.service.CommerceChannelAccountEntryRelLocalS
 import com.liferay.commerce.product.service.CommerceChannelLocalService;
 import com.liferay.commerce.service.CommerceAddressService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CountryModel;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -66,9 +68,22 @@ public class ShippingAddressCheckoutStepDisplayContext
 	public List<CommerceAddress> getCommerceAddresses() throws PortalException {
 		CommerceOrder commerceOrder = getCommerceOrder();
 
-		return commerceAddressService.getShippingCommerceAddresses(
-			commerceOrder.getCompanyId(), AccountEntry.class.getName(),
-			commerceOrder.getCommerceAccountId());
+		List<CommerceAddress> addresses =
+			commerceAddressService.getShippingCommerceAddresses(
+				commerceOrder.getCompanyId(), AccountEntry.class.getName(),
+				commerceOrder.getCommerceAccountId());
+
+		List<CommerceAddress> availableAddresses = new ArrayList<>();
+
+		for (CommerceAddress address : addresses) {
+			CountryModel country = address.getCountry();
+
+			if (country.isShippingAllowed()) {
+				availableAddresses.add(address);
+			}
+		}
+
+		return availableAddresses;
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/util/AddressCommerceCheckoutStepUtil.java
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/java/com/liferay/commerce/checkout/web/internal/util/AddressCommerceCheckoutStepUtil.java
@@ -25,10 +25,12 @@ import com.liferay.commerce.constants.CommerceWebKeys;
 import com.liferay.commerce.context.CommerceContext;
 import com.liferay.commerce.exception.CommerceOrderBillingAddressException;
 import com.liferay.commerce.exception.CommerceOrderShippingAddressException;
+import com.liferay.commerce.exception.CommerceOrderShippingAndBillingException;
 import com.liferay.commerce.model.CommerceAddress;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.service.CommerceAddressService;
 import com.liferay.commerce.service.CommerceOrderService;
+import com.liferay.portal.kernel.model.CountryModel;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
@@ -112,6 +114,12 @@ public class AddressCommerceCheckoutStepUtil {
 
 			CommerceAddress commerceAddress =
 				_commerceAddressService.getCommerceAddress(commerceAddressId);
+
+			CountryModel addressCountry = commerceAddress.getCountry();
+
+			if (!addressCountry.isBillingAllowed()) {
+				throw new CommerceOrderShippingAndBillingException();
+			}
 
 			_commerceAddressService.updateCommerceAddress(
 				commerceAddressId, commerceAddress.getName(),

--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
@@ -98,6 +98,7 @@ boolean hasManageAddressesPermission = baseAddressCheckoutStepDisplayContext.has
 	<liferay-ui:error exception="<%= CommerceAddressZipException.class %>" message="please-enter-a-valid-zip" />
 	<liferay-ui:error exception="<%= CommerceOrderBillingAddressException.class %>" message="please-enter-a-valid-address" />
 	<liferay-ui:error exception="<%= CommerceOrderShippingAddressException.class %>" message="please-enter-a-valid-address" />
+	<liferay-ui:error exception="<%= CommerceOrderShippingAndBillingException.class %>" message="cannot-use-this-country-for-billing-address" />
 
 	<aui:model-context bean="<%= baseAddressCheckoutStepDisplayContext.getCommerceAddress(commerceAddressId) %>" model="<%= CommerceAddress.class %>" />
 

--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/init.jsp
@@ -54,6 +54,7 @@ page import="com.liferay.commerce.exception.CommerceOrderDefaultBillingAddressEx
 page import="com.liferay.commerce.exception.CommerceOrderGuestCheckoutException" %><%@
 page import="com.liferay.commerce.exception.CommerceOrderPaymentMethodException" %><%@
 page import="com.liferay.commerce.exception.CommerceOrderShippingAddressException" %><%@
+page import="com.liferay.commerce.exception.CommerceOrderShippingAndBillingException" %><%@
 page import="com.liferay.commerce.exception.CommerceOrderShippingMethodException" %><%@
 page import="com.liferay.commerce.model.CommerceAddress" %><%@
 page import="com.liferay.commerce.model.CommerceOrder" %><%@

--- a/modules/apps/commerce/commerce-service/service.xml
+++ b/modules/apps/commerce/commerce-service/service.xml
@@ -933,6 +933,7 @@
 		<exception>CommerceOrderPurchaseOrderNumber</exception>
 		<exception>CommerceOrderRequestedDeliveryDate</exception>
 		<exception>CommerceOrderShippingAddress</exception>
+		<exception>CommerceOrderShippingAndBilling</exception>
 		<exception>CommerceOrderShippingMethod</exception>
 		<exception>CommerceOrderStatus</exception>
 		<exception>CommerceOrderTypeDisplayDate</exception>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again.
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}.
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address.
 canonical-url=Canonical URL
 canvas-page-url=Canvas Page URL
 caps-lock-is-on=Caps Lock is on.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=لا يمكن حذف مكتبة الأصول المرحلية. قم بإلغاء مرحلة مكتبة الأصول وأعد المحاولة.
 cannot-open-the-requested-document-due-to-the-following-reason=لا يمكن فتح المستند المطلوب للسبب الآتي: {0}
 cannot-update-permissions-for-an-owner=لا يمكن تحديث الأذونات لمالك.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=عنوان URL متعارف عليه
 canvas-page-url=رابط لوحة صفحة
 caps-lock-is-on=Caps Lock مشغل.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Не може да се актуализират разрешенията за собственик. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Каноничен URL адрес (Automatic Translation)
 canvas-page-url=URL адрес на страница от платно (Automatic Translation)
 caps-lock-is-on=Главните букви са включени.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=No es pot suprimir una biblioteca de continguts per fases. Elimina les fases de la biblioteca de continguts i torna-ho a provar.
 cannot-open-the-requested-document-due-to-the-following-reason=No es pot obrir el document sol·licitat pel motiu següent: {0}
 cannot-update-permissions-for-an-owner=No es poden actualitzar els permisos per a un propietari.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canònic
 canvas-page-url=L'URL de la pàgina de treball
 caps-lock-is-on=Les majúscules estan activades.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Nepodařilo se otevřít požadovaný dokument z následujícího důvodu: {0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=URL stránky s plátnem (canvas page)
 caps-lock-is-on=Caps Lock je zapnutý.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Tilladelserne for en ejer kan ikke opdateres. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanonisk URL-adresse (Automatic Translation)
 canvas-page-url=Canvas side URL
 caps-lock-is-on=Caps Lock is on. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Eine bereitgestellte Assetbibliothek kann nicht gelöscht werden. Heben Sie die Bereitstellung auf und versuchen Sie es erneut.
 cannot-open-the-requested-document-due-to-the-following-reason=Das angeforderte Dokument kann aus folgendem Grund nicht geöffnet werden: {0}
 cannot-update-permissions-for-an-owner=Sie können Berechtigungen für einen Besitzer nicht aktualisieren.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanonische URL
 canvas-page-url=Canvas URL
 caps-lock-is-on=Feststelltaste ist aktiviert.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Το έγγραφο που ζητήσατε δεν είναι δυνατόν να ανοιχτεί για τον εξής λόγο: {0}
 cannot-update-permissions-for-an-owner=Δεν είναι δυνατή η ενημέρωση δικαιωμάτων για έναν κάτοχο. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Μειονοτική διεύθυνση URL (Automatic Translation)
 canvas-page-url=URL σελίδας καμβά
 caps-lock-is-on=Είναι πατημένη η κλειδαριά κεφαλαίων (caps lock)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again.
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}.
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address.
 canonical-url=Canonical URL
 canvas-page-url=Canvas Page URL
 caps-lock-is-on=Caps Lock is on.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=Canvas Page URL (Automatic Copy)
 caps-lock-is-on=Caps Lock is on. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=Canvas Page URL (Automatic Copy)
 caps-lock-is-on=Caps Lock is on. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=No se puede eliminar un repositorio staged. Quite el repositorio del estado staged y vuelva a intentarlo.
 cannot-open-the-requested-document-due-to-the-following-reason=No es posible abrir el documento solicitado debido a: {0}
 cannot-update-permissions-for-an-owner=No se pueden actualizar los permisos de un propietario.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canónica
 canvas-page-url=URL de la página de canvas
 caps-lock-is-on=El bloqueo de mayúsculas está habilitado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=No se puede eliminar un repositorio staged. Quite el repositorio del estado staged y vuelva a intentarlo.
 cannot-open-the-requested-document-due-to-the-following-reason=No es posible abrir el documento solicitado debido a: {0}
 cannot-update-permissions-for-an-owner=No se pueden actualizar los permisos de un propietario.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canónica
 canvas-page-url=URL de la página de canvas
 caps-lock-is-on=El bloqueo de mayúsculas está habilitado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=No se puede eliminar un repositorio staged. Quite el repositorio del estado staged y vuelva a intentarlo.
 cannot-open-the-requested-document-due-to-the-following-reason=No es posible abrir el documento solicitado debido a: {0}
 cannot-update-permissions-for-an-owner=No se pueden actualizar los permisos de un propietario.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canónica
 canvas-page-url=URL de la página de canvas
 caps-lock-is-on=El bloqueo de mayúsculas está habilitado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=No se puede eliminar un repositorio staged. Quite el repositorio del estado staged y vuelva a intentarlo.
 cannot-open-the-requested-document-due-to-the-following-reason=No es posible abrir el documento solicitado debido a: {0}
 cannot-update-permissions-for-an-owner=No se pueden actualizar los permisos de un propietario.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canónica
 canvas-page-url=URL de la página de canvas
 caps-lock-is-on=El bloqueo de mayúsculas está habilitado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Omaniku õigusi ei saa värskendada. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanooniline URL (Automatic Translation)
 canvas-page-url=Lõuendilehe URL (Automatic Translation)
 caps-lock-is-on=Suurtähe lukk on peal.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Ezin da zabaldu eskatutako dokumentua ondorengoko arrazoiagatik: {0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL kanonikoa
 canvas-page-url=Canvas orriaren URLa
 caps-lock-is-on=Blok Maius gaituta dago.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=سند خواسته شده به دلایل زیر باز نمی‌شود: {0}
 cannot-update-permissions-for-an-owner=نمی تواند مجوزها را برای مالک به روز کند. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=آدرس Canonical
 canvas-page-url=آدرس صفحه
 caps-lock-is-on=کلید caps lock روشن است.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Vaiheistetun resurssikirjaston poistaminen ei onnistu. Poista resurssikirjaston vaiheistus ja yritä uudelleen.
 cannot-open-the-requested-document-due-to-the-following-reason=Asiakirjaa ei voi avata, johtuen seuraavasta syystä: {0}
 cannot-update-permissions-for-an-owner=Omistajan oikeuksien päivittäminen ei onnistu.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanoninen URL
 canvas-page-url=Canvas sivun URL
 caps-lock-is-on=Caps Lock on päällä.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Impossible de supprimer un dépôt en pré-production. Sortez le dépôt de la pré-production et réessayez.
 cannot-open-the-requested-document-due-to-the-following-reason=Impossible d'ouvrir le document demandé pour la raison suivante : {0}
 cannot-update-permissions-for-an-owner=Impossible de mettre à jour les autorisations pour un propriétaire.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canonique
 canvas-page-url=URL de page de toile
 caps-lock-is-on=La fonction majuscule est allumée.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Impossible d'ouvrir le document demandé pour la raison suivante : {0}
 cannot-update-permissions-for-an-owner=Impossible de mettre à jour les autorisations pour un propriétaire.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canonique
 canvas-page-url=URL de page de toile
 caps-lock-is-on=La fonction majuscule est allumée.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canónico
 canvas-page-url=URL da páxina de canvas
 caps-lock-is-on=O bloqueo de mayúsculas está habilitado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=किसी मालिक के लिए अनुमतियों को अपडेट नहीं कर सकते. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=विहित यूआरएल (Automatic Translation)
 canvas-page-url=कैनवास पेज यूआरल
 caps-lock-is-on=कैप्स लॉक ऑन है

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Traženi dokument nije moguće otvoriti iz slijedećeg razloga: {0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=Canvas URL stranice
 caps-lock-is-on=Caps Lock je uključen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Az átmeneti adattárak nem törölhetők. Vonja vissza az adattár átmeneti jellegét, és próbálja újra.
 cannot-open-the-requested-document-due-to-the-following-reason=Nem nyitható meg a kért dokumentum a következő ok miatt: {0}
 cannot-update-permissions-for-an-owner=A tulajdonos jogosultságai nem frissíthetők.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanonikus URL
 canvas-page-url=Vászon URL címe
 caps-lock-is-on=A Caps Lock be van kapcsolva.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Tidak dapat membuka dokumen yang diminta karena alasan berikut: {0}
 cannot-update-permissions-for-an-owner=Tak bisa memutakhirkan ijin untuk pemilik. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL Kanonikal (Automatic Translation)
 canvas-page-url=Halaman kanvas URL
 caps-lock-is-on=Caps Lock aktif.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -2693,6 +2693,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Non si può aprire questo documento per la ragione seguente: {0}
 cannot-update-permissions-for-an-owner=Impossibile aggiornare le autorizzazioni per un proprietario. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canonico (Automatic Translation)
 canvas-page-url=URL della Pagina Canvas
 caps-lock-is-on=Caps Lock attivo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=לא ניתן לפתוח את המסמך המבוקש בגלל הסיבה הבאה: {0}
 cannot-update-permissions-for-an-owner=אין אפשרות לעדכן הרשאות עבור בעלים. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=כתובת URL קנונית (Automatic Translation)
 canvas-page-url=כתובת אינטרנט של דף קנבס
 caps-lock-is-on=Caps Lock מופעל

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=ステージング済みのアセットライブラリは削除できません。ステージングを解除してから再度お試しください。
 cannot-open-the-requested-document-due-to-the-following-reason=次の理由のため指摘されたドキュメントが開けません:{0}
 cannot-update-permissions-for-an-owner=所有者の権限を更新できません。
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=正規化URL
 canvas-page-url=キャンバスページ URL
 caps-lock-is-on=Caps Lockが有効になっています

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=Canvas Page URL (Automatic Copy)
 caps-lock-is-on=Caps Lock is on. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=스테이징된 애셋 라이브러리는 삭제할 수 없습니다. 애셋 라이브러리를 스테이징 해제한 후 다시 시도하십시오.
 cannot-open-the-requested-document-due-to-the-following-reason=다음 사유로 요청하신 문서를 열 수 없습니다: {0}
 cannot-update-permissions-for-an-owner=소유자 권한을 업데이트 할 수 없습니다.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=캐노니컬 URL
 canvas-page-url=화포 페이지 URL
 caps-lock-is-on=대문자 록은 켜져있는다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=ບໍ່ສາມາດເປີດເອກະສານຍ້ອນເຫດຜົນຕໍ່ໄປນີ້:{0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=ໜ້າຂອງ URL
 caps-lock-is-on=ແຄ໋ບລ໋ອກ ກຳລັງເປີດ.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Negalima atnaujinti savininko teisių. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanoninis URL (Automatic Translation)
 canvas-page-url=Drobės puslapio URL (Automatic Translation)
 caps-lock-is-on="Caps Lock" įjungtas. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Tidak dapat mengemaskini keizinan untuk pemilik. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL berkanun (Automatic Translation)
 canvas-page-url=URL Halaman Kanvas (Automatic Translation)
 caps-lock-is-on=Caps Lock disenyapkan. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Dokumentet kan ikke åpnes av følgende årsak: {0}
 cannot-update-permissions-for-an-owner=Kan ikke oppdatere tillatelser for en eier. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanonisk URL
 canvas-page-url=Canvas sideadresse
 caps-lock-is-on=Caps-lock er på.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Het is niet mogelijk om een assetbibliotheek in uitvoering te verwijderen. Stop de uitvoering van de assetbibliotheek en probeer het opnieuw.
 cannot-open-the-requested-document-due-to-the-following-reason=Het opgevraagde document kan niet worden geopend doordat: {0}
 cannot-update-permissions-for-an-owner=Kan machtigingen voor een eigenaar niet bijwerken.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonieke URL
 canvas-page-url=URL van canvaspagina
 caps-lock-is-on=Caps Lock staat aan.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Het opgevraagde document kan niet worden geopend doordat: {0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=De URL van de canvaspagina
 caps-lock-is-on="Caps Lock" staat aan

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Nie można otworzyć tego dokumentu z powodu: {0}
 cannot-update-permissions-for-an-owner=Nie można zaktualizować uprawnień właściciela. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanoniczny adres URL (Automatic Translation)
 canvas-page-url=URL strony wzorcowej
 caps-lock-is-on=Caps Lock jest włączony.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Não é possível excluir uma biblioteca de ativos preparada. Desprepare a biblioteca de conteúdo e tente novamente.
 cannot-open-the-requested-document-due-to-the-following-reason=Não é possível abrir o documento requisitado pela seguinte razão: {0}
 cannot-update-permissions-for-an-owner=Não é possível atualizar permissões para um proprietário.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canônica
 canvas-page-url=URL da página Canvas
 caps-lock-is-on=Caps Lock está ativado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=O documento requerido não pode ser aberto pelo seguinte motivo: {0}
 cannot-update-permissions-for-an-owner=Não é possível atualizar permissões para um proprietário. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canônico (Automatic Translation)
 canvas-page-url=URL da Página da Tela
 caps-lock-is-on=Caps Lock está activo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Imposibil de actualizat permisiunile pentru un proprietar. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL canonic (Automatic Translation)
 canvas-page-url=URL pagină pânză (Automatic Translation)
 caps-lock-is-on=Caps Lock este apăsat.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Невозможно открыть запрашиваемый документ по причине: {0}
 cannot-update-permissions-for-an-owner=Не может обновлять разрешения для владельца. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Канонический URL (Automatic Translation)
 canvas-page-url=URL страницы Canvas
 caps-lock-is-on=Caps Lock включен.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Nemôžem otvoriť požadovaný dokument z nasledovného dôvodu: {0}
 cannot-update-permissions-for-an-owner=Nie je možné aktualizovať povolenia pre vlastníka. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanonická adresa URL (Automatic Translation)
 canvas-page-url=URL stránky s plátnom (canvas page)
 caps-lock-is-on=Caps Lock je zapnutý.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Dovoljenja za lastnika ni mogoče posodobiti. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Translation)
 canvas-page-url=URL strani na platnu (Automatic Translation)
 caps-lock-is-on=Caps Lock je vklopljen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Не могу да се отворе жељени документи из следећих разлога: {0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=Канвас Странице УРЛ
 caps-lock-is-on=Укључен тастер Капс Лок.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Ne mogu da se otvore željeni dokumenti iz sledećih razloga: {0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=Kanvas Stranice URL
 caps-lock-is-on=Uključen taster Kaps Lok.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Det går inte att ta bort ett mellanlagrat tillgångsbibliotek. Ta bort mellanlagring för tillgångsbibliotek och försök igen.
 cannot-open-the-requested-document-due-to-the-following-reason=Det går inte att öppna det begärda dokumentet på grund av följande fel: {0}
 cannot-update-permissions-for-an-owner=Det går inte att uppdatera behörigheter för en ägare.
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kanonisk URL
 canvas-page-url=Kanvas sid-URL
 caps-lock-is-on=Skiftlås på på tangentbordet

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=பின்வரும் காரணங்களினால் காரணமாக கோரிய ஆவணத்தை திறக்க முடியவில்லை: {0}
 cannot-update-permissions-for-an-owner=Cannot update permissions for an owner. (Automatic Copy)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL (Automatic Copy)
 canvas-page-url=Canvas Page URL (Automatic Copy)
 caps-lock-is-on=Caps Lock பட்டன் ஆன்-ல் உள்ளது.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=ไม่สามารถลบคลังแอสเซทที่ถูกสเตจแล้ว ลองอันยกเลิกการสเตจคลังแอสเซทและลองใหม่อีกครั้ง
 cannot-open-the-requested-document-due-to-the-following-reason=ไม่สามารถเปิดเอกสารที่ร้องขอได้เนื่องจากเหตุผลดังต่อไปนี้: {0}
 cannot-update-permissions-for-an-owner=ไม่สามารถอัพเดทสิทธิ์สำหรับเจ้าของ
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=คาโนนิคอล URL
 canvas-page-url=แคนวาสเพจ URL
 caps-lock-is-on=Caps Lock ถูกเปิดใช้งานอยู่

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Sahip izinleri güncelleştirilemiyor. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Kurallı URL (Automatic Translation)
 canvas-page-url=Taslak Sayfa Adresi
 caps-lock-is-on=Caps Lock Açık.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Cannot open the requested document due to the following reason: {0}. (Automatic Copy)
 cannot-update-permissions-for-an-owner=Не вдалося оновити дозволи для власника. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Канонічна URL-адреса (Automatic Translation)
 canvas-page-url=URL-адреса сторінки полотна (Automatic Translation)
 caps-lock-is-on=Caps Lock включено.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=Hệ thống không thể mở tài liệu yêu cầu vì lí do sau: {0}
 cannot-update-permissions-for-an-owner=Không thể cập nhật quyền cho chủ sở hữu. (Automatic Translation)
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=URL chuẩn (Automatic Translation)
 canvas-page-url=Canvas Trang URL
 caps-lock-is-on=Phím chuyển chữ hoa đang bật.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=无法删除暂存资产库。取消暂存该资产库并重试。
 cannot-open-the-requested-document-due-to-the-following-reason=由于下列原因：{0}，不能打开所请求的文件
 cannot-update-permissions-for-an-owner=无法更新所有者的权限。
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=规范 URL
 canvas-page-url=Canvas页面URL
 caps-lock-is-on=大写锁定键处于打开状态。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -2694,6 +2694,7 @@ cannot-delete-a-document-type-that-is-presently-used-by-one-or-more-documents-in
 cannot-delete-a-staged-asset-library.-unstage-the-asset-library-and-try-again=Cannot delete a staged asset library. Unstage the asset library and try again. (Automatic Copy)
 cannot-open-the-requested-document-due-to-the-following-reason=不能開啟請求文件，因為下列原因：{0}
 cannot-update-permissions-for-an-owner=無法更新所有者的權限。
+cannot-use-this-country-for-billing-address=Cannot use this Country for Billing Address. (Automatic Copy)
 canonical-url=Canonical URL
 canvas-page-url=帆布頁面網址
 caps-lock-is-on=開啟大寫鍵。


### PR DESCRIPTION
Related Issue: [COMMERCE-10759](https://issues.liferay.com/browse/COMMERCE-10759)

Problem was that the Countries weren't being filtered before being shown at the select menu.
Proposed fix is to filter the Countries, and make it not possible to select an address as Billing and Shipping, if the address uses a Country that can be used for Billing, but not Shipping.