### PR TITLE
COMMERCE-10760 - Checkout: can add new address on-the-go with country for which billing/shipping is disabled

### DIFF
--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
@@ -406,8 +406,19 @@ boolean hasManageAddressesPermission = baseAddressCheckoutStepDisplayContext.has
 								},
 							];
 
+							var isShippingStep = <%= baseAddressCheckoutStepDisplayContext.getTitle() == "shipping-address" %>;
+
 							list.forEach((listElement) => {
-								callbackList.push(listElement);
+								if (isShippingStep) {
+									if (listElement.shippingAllowed) {
+										callbackList.push(listElement);
+									}
+								}
+								else {
+									if (listElement.billingAllowed) {
+										callbackList.push(listElement);
+									}
+								}
 							});
 
 							callback(callbackList);


### PR DESCRIPTION
Related issue: [COMMERCE-10760](https://issues.liferay.com/browse/COMMERCE-10760)

Problem was that there was no filtering being done on the addresses before being displayed as a select option.
Proposed fix is to filter the addresses with the available countries before being showed as options.