### PR TITLE
COMMERCE-9743 - Delivery Subscription is visible on the SF even if it's not enabled, with multiple SKUs product

### DIFF
--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/view.jsp
@@ -147,8 +147,8 @@ long cpDefinitionId = cpCatalogEntry.getCPDefinitionId();
 					/>
 				</c:if>
 
-				<span data-text-cp-instance-subscription-info></span>
-				<span data-text-cp-instance-delivery-subscription-info></span>
+				<span style="display: block" data-text-cp-instance-subscription-info></span>
+				<span style="display: block" data-text-cp-instance-delivery-subscription-info></span>
 			</h4>
 
 			<div class="product-detail-options">

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/product/content/contributor/DeliverySubscriptionInfoCPContentContributor.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/product/content/contributor/DeliverySubscriptionInfoCPContentContributor.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.internal.product.content.contributor;
 
 import com.liferay.commerce.product.constants.CPContentContributorConstants;
+import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CPSubscriptionInfo;
 import com.liferay.commerce.product.model.CommerceChannel;
@@ -71,10 +72,14 @@ public class DeliverySubscriptionInfoCPContentContributor
 			return jsonObject;
 		}
 
-		jsonObject.put(
-			CPContentContributorConstants.DELIVERY_SUBSCRIPTION_INFO,
-			_getSubscriptionInfo(
-				cpInstance.getCPSubscriptionInfo(), httpServletRequest));
+		CPDefinition cpDefinition = cpInstance.getCPDefinition();
+
+		if (cpDefinition.isDeliverySubscriptionEnabled()) {
+			jsonObject.put(
+				CPContentContributorConstants.DELIVERY_SUBSCRIPTION_INFO,
+				_getSubscriptionInfo(
+					cpInstance.getCPSubscriptionInfo(), httpServletRequest));
+		}
 
 		return jsonObject;
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/product/content/contributor/SubscriptionInfoCPContentContributor.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/product/content/contributor/SubscriptionInfoCPContentContributor.java
@@ -15,6 +15,7 @@
 package com.liferay.commerce.internal.product.content.contributor;
 
 import com.liferay.commerce.product.constants.CPContentContributorConstants;
+import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CPSubscriptionInfo;
 import com.liferay.commerce.product.model.CommerceChannel;
@@ -72,10 +73,14 @@ public class SubscriptionInfoCPContentContributor
 			return jsonObject;
 		}
 
-		jsonObject.put(
-			CPContentContributorConstants.SUBSCRIPTION_INFO,
-			_getSubscriptionInfo(
-				cpInstance.getCPSubscriptionInfo(), httpServletRequest));
+		CPDefinition cpDefinition = cpInstance.getCPDefinition();
+
+		if (cpDefinition.isSubscriptionEnabled()) {
+			jsonObject.put(
+				CPContentContributorConstants.SUBSCRIPTION_INFO,
+				_getSubscriptionInfo(
+					cpInstance.getCPSubscriptionInfo(), httpServletRequest));
+		}
 
 		return jsonObject;
 	}


### PR DESCRIPTION
Relevant Issues: [COMMERCE-9743](https://issues.liferay.com/browse/COMMERCE-9743), [COMMERCE-9742](https://issues.liferay.com/browse/COMMERCE-9742)

Problem was that there was no check to see if the product's subscriptions are enabled before being shown in the store page.
Proposed fix is to check if they are enabled before being shown.
The COMMERCE-9742 fix is an easy change of display type, so that each subscription is in their own line