### PR TITLE
COMMERCE-9601 - In a Channel, users without the permission to set Permissions can still see the Permissions menu item on the payment method's ellipsis

### DIFF
--- a/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/frontend/data/set/view/table/CommercePaymentMethodTableFDSView.java
+++ b/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/frontend/data/set/view/table/CommercePaymentMethodTableFDSView.java
@@ -43,6 +43,9 @@ import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -113,7 +116,17 @@ public class CommercePaymentMethodTableFDSView
 				fetchCommercePaymentMethodGroupRel(
 					commerceChannel.getGroupId(), paymentMethod.getKey());
 
-		if (commercePaymentMethodGroupRel != null) {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if ((commercePaymentMethodGroupRel != null) &&
+			permissionChecker.hasPermission(
+				commercePaymentMethodGroupRel.getGroupId(),
+				CommercePaymentMethodGroupRel.class.getName(),
+				commercePaymentMethodGroupRel.
+					getCommercePaymentMethodGroupRelId(),
+				ActionKeys.PERMISSIONS)) {
+
 			dropdownItemList.add(
 				dropdownItem -> {
 					dropdownItem.setHref(


### PR DESCRIPTION
Related Issue: [COMMERCE-9601](https://issues.liferay.com/browse/COMMERCE-9601)

Problem was that there was no check to see if user had the "Permissions" permission before showing the dropdown button.
Proposed fix is to check user's permissions before showing the button.