### PR TITLE
LPD-15425 - user notification API can return a NPE due to headless API not having a themeDisplay

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/notifications/ExportImportUserNotificationHandler.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/notifications/ExportImportUserNotificationHandler.java
@@ -75,7 +75,9 @@ public class ExportImportUserNotificationHandler
 		BackgroundTask backgroundTask =
 			_backgroundTaskLocalService.fetchBackgroundTask(backgroundTaskId);
 
-		if (backgroundTask == null) {
+		if ((backgroundTask == null) ||
+			(serviceContext.getThemeDisplay() == null)) {
+
 			return StringPool.BLANK;
 		}
 


### PR DESCRIPTION
Hi @brianikim ,

https://liferay.atlassian.net/browse/LPD-15425, linked to LPP.

An NPE can be thrown when using headless API to retrieve export/import notifications due to how user notifications are handled in ExportImportNotificationHandler. In ExportImportNotificationHandler.getLink(), we call PortletURLFactoryUtil.create() which eventually attempts to retrieve a ThemeDisplay. Since we do not have one due to the nature of our call, an NPE is thrown. I've added a check for it as null, similar to the one that [already exists for WorkflowTasks](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java#L244-L248).