### PR TITLE
LPD-15689 - save button in account settings for Roles is non-functional

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1101,7 +1101,7 @@ jdbc.default.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 				</else>
 			</if>
 
-			<echo>## Using ${java.jdk.home} as JAVA_HOME</echo>
+			<echo>## Using ${java.jdk.home} as JAVA_HOME.</echo>
 		</sequential>
 	</macrodef>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -1100,6 +1100,8 @@ jdbc.default.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 					</if>
 				</else>
 			</if>
+
+			<echo>## Using ${java.jdk.home} as JAVA_HOME</echo>
 		</sequential>
 	</macrodef>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -16812,6 +16812,7 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 							failonerror="true"
 							fork="true"
 							jar="${liferay.home}/tools/portal-tools-db-upgrade-client/com.liferay.portal.tools.db.upgrade.client.jar"
+							jvm="${java.jdk.home}/bin/java"
 							timeout="${upgrade.client.timeout}"
 						>
 							<env key="JAVA_HOME" value="${java.jdk.home}" />
@@ -16824,6 +16825,7 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 							failonerror="true"
 							fork="true"
 							jar="${liferay.home}/tools/portal-tools-db-upgrade-client/com.liferay.portal.tools.db.upgrade.client.jar"
+							jvm="${java.jdk.home}/bin/java"
 							timeout="${upgrade.client.timeout}"
 						>
 							<env key="JAVA_HOME" value="${java.jdk.home}" />

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/js/PersonalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/js/PersonalMenu.js
@@ -102,6 +102,7 @@ function PersonalMenu({
 							userName
 						)}
 						className="rounded-circle"
+						data-testid="userPersonalMenu"
 						displayType="unstyled"
 						onFocus={preloadItems}
 						onMouseOver={preloadItems}

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserMembershipsScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserMembershipsScreenNavigationEntry.java
@@ -5,9 +5,16 @@
 
 package com.liferay.users.admin.web.internal.frontend.taglib.servlet.taglib;
 
+import com.liferay.admin.kernel.util.PortalMyAccountApplicationType;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.PortletProvider;
+import com.liferay.portal.kernel.portlet.PortletProviderUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.users.admin.constants.UserScreenNavigationEntryConstants;
 
 import java.io.IOException;
@@ -46,6 +53,28 @@ public class UserMembershipsScreenNavigationEntry
 	@Override
 	public String getJspPath() {
 		return "/user/memberships.jsp";
+	}
+
+	public boolean isEditable(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		String myAccountPortletId = PortletProviderUtil.getPortletId(
+			PortalMyAccountApplicationType.MyAccount.CLASS_NAME,
+			PortletProvider.Action.VIEW);
+
+		if (myAccountPortletId.equals(portletDisplay.getPortletName())) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserRolesScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserRolesScreenNavigationEntry.java
@@ -5,11 +5,21 @@
 
 package com.liferay.users.admin.web.internal.frontend.taglib.servlet.taglib;
 
+import com.liferay.admin.kernel.util.PortalMyAccountApplicationType;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.PortletProvider;
+import com.liferay.portal.kernel.portlet.PortletProviderUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.users.admin.constants.UserScreenNavigationEntryConstants;
 
 import org.osgi.service.component.annotations.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author Pei-Jung Lan
@@ -39,6 +49,28 @@ public class UserRolesScreenNavigationEntry
 	@Override
 	public String getJspPath() {
 		return "/user/roles.jsp";
+	}
+
+	public boolean isEditable(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		String myAccountPortletId = PortletProviderUtil.getPortletId(
+			PortalMyAccountApplicationType.MyAccount.CLASS_NAME,
+			PortletProvider.Action.VIEW);
+
+		if (myAccountPortletId.equals(portletDisplay.getPortletName())) {
+			return false;
+		}
+
+		return true;
 	}
 
 	@Override

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserRolesScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserRolesScreenNavigationEntry.java
@@ -16,10 +16,10 @@ import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.users.admin.constants.UserScreenNavigationEntryConstants;
 
-import org.osgi.service.component.annotations.Component;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Pei-Jung Lan

--- a/modules/test/playwright/fixtures/accountSettingsPagesTest.ts
+++ b/modules/test/playwright/fixtures/accountSettingsPagesTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {AccountSettingsPage} from '../pages/users-admin-web/AccountSettingsPage';
+
+const accountSettingsPageTest = test.extend<{
+	accountSettingsPage: AccountSettingsPage;
+}>({
+	accountSettingsPage: async ({page}, use) => {
+		await use(new AccountSettingsPage(page));
+	},
+});
+
+export {accountSettingsPageTest};

--- a/modules/test/playwright/pages/users-admin-web/AccountSettingsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/AccountSettingsPage.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {Locator, Page} from '@playwright/test';
+
+export class AccountSettingsPage {
+    readonly accountSettingsMenuItem: Locator;
+    readonly page: Page;
+    readonly personalMenuButton: Locator;
+    readonly rolesMenuItem: Locator;
+    readonly saveButton: Locator;
+
+    constructor(page: Page) {
+        this.accountSettingsMenuItem = page.getByRole('menuitem', {
+                name: 'Account Settings'
+            });
+        this.personalMenuButton = page.getByLabel('Test Test User Profile');
+        this.rolesMenuItem = page.getByRole('link', {
+                name: 'Roles'
+            });
+        this.saveButton = page.getByRole('button', {
+                name: 'Save'
+            });
+        this.page = page;
+    }
+
+    async goToAccountSettings() {
+        await this.personalMenuButton.click();
+        await this.accountSettingsMenuItem.click();
+    }
+
+    async goToAccountSettingsRoles() {
+        await this.goToAccountSettings();
+        await Promise.all([
+            this.rolesMenuItem.click(),
+            this.page.waitForResponse(
+                (resp) =>
+                resp.status() === 200 &&
+                resp.url().includes('screenNavigationEntryKey=roles')
+            ),
+        ]);
+    }
+}

--- a/modules/test/playwright/pages/users-admin-web/AccountSettingsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/AccountSettingsPage.ts
@@ -18,7 +18,7 @@ export class AccountSettingsPage {
         this.accountSettingsMenuItem = page.getByRole('menuitem', {
                 name: 'Account Settings'
             });
-        this.personalMenuButton = page.getByLabel('Test Test User Profile');
+        this.personalMenuButton = page.getByTestId('userPersonalMenu');
         this.rolesMenuItem = page.getByRole('link', {
                 name: 'Roles'
             });

--- a/modules/test/playwright/tests/users-admin-web/accountSettingsRoles.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/accountSettingsRoles.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {accountSettingsPageTest} from '../../fixtures/accountSettingsPagesTest';
+import {loginTest} from '../../fixtures/loginTest';
+
+import {expect, mergeTests} from '@playwright/test';
+
+export const test = mergeTests(accountSettingsPageTest, loginTest);
+
+test('LPD-15689 - roles in account settings should have no save button', async ({
+    accountSettingsPage
+}) => {
+    await accountSettingsPage.goToAccountSettingsRoles();
+
+    await expect(
+        accountSettingsPage.saveButton
+    ).toBeHidden({
+        timeout: 8 * 1000,
+    });
+
+})

--- a/modules/test/playwright/tests/users-admin-web/accountSettingsRoles.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/accountSettingsRoles.spec.ts
@@ -17,7 +17,7 @@ test('LPD-15689 - roles in account settings should have no save button', async (
 
     await expect(
         accountSettingsPage.saveButton
-    ).toBeHidden({
+    ).not.toBeVisible({
         timeout: 8 * 1000,
     });
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-15689, tied to LPP.

Currently the save button appears, but has no functionality on both the roles and memberships pages of the Account Settings portlet. This is causing user confusion since they would expect to be able to make changes due to the presence of a save button. Using the pre-existing isEditable() logic in usersOrganizationsScreenNavigationEntry, we can apply it to both the roles and memberships pages as well, hiding the button in the case of being accessed through Account Settings. 

@brianikim Also included is a very basic functional test. I've been trying to refine it a bit using what you've mentioned with Fixtures, but I wanted to make sure I'm fully understanding what is or isn't necessary since I'm struggling a bit with the fixture/helpers/pages side of things. So obviously a Page represents a single view and we for example, have ApplicationsMenuPage and then UsersAndOrganizationsPage which builds on it further. Would the Personal Menu have its own page then (despite it technically being a drop-down)? For example, would a PersonalMenuPage have a locator for the Account Settings option and then we'd have an AccountSettingsPage which would have locators corresponding with:

```
    await page.getByRole('link', { name: 'Roles' }).click();

    await expect(page.getByRole('button', { name: 'Save' }))
    .toBeHidden({
        timeout: 8 * 1000,
    });
```

We would then also have a fixture for both the PersonalMenuPage and the AccountSettingsPage. Is this a correct breakdown? Thanks in advance!

As a note I've put the LPD as "In Review" so it appears on your dashboard but I know this is probably going to require additional work on the test.