### PR TITLE
LPD-17299 - Cannot add more than one item to the wishlist when products have options

### DIFF
--- a/modules/apps/commerce/commerce-frontend-impl/src/main/java/com/liferay/commerce/frontend/internal/wishlist/CommerceWishListResource.java
+++ b/modules/apps/commerce/commerce-frontend-impl/src/main/java/com/liferay/commerce/frontend/internal/wishlist/CommerceWishListResource.java
@@ -115,9 +115,9 @@ public class CommerceWishListResource {
 
 			long commerceWishListItemCount =
 				_commerceWishListItemService.
-					getCommerceWishListItemByContainsCPInstanceCount(
+					getCommerceWishListItemByContainsCProductCount(
 						commerceWishList.getCommerceWishListId(),
-						cpInstanceUuid);
+						cpCatalogEntry.getCProductId());
 
 			if (commerceWishListItemCount == 0) {
 				_commerceWishListItemService.addCommerceWishListItem(


### PR DESCRIPTION
[LPD-17299](https://liferay.atlassian.net/browse/LPD-17299)

- The method being used for getting the item count has [cpInstanceUuid](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/commerce/commerce-frontend-impl/src/main/java/com/liferay/commerce/frontend/internal/wishlist/CommerceWishListResource.java#L120) as a param
- If you try to add products with option variants in the wishlist, they will use null as the cpInstanceUuid
the getCommerceWishListItemByContainsCPInstanceCount will return 1 because there's already a product in the wish list with null as the cpInstanceUuid
- So instead of adding the product, the code will try to [remove it from the wishlist](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/commerce/commerce-frontend-impl/src/main/java/com/liferay/commerce/frontend/internal/wishlist/CommerceWishListResource.java#L122-L140), causing the exception.
- The solution is to use getCommerceWishListItemByContainsCProductCount instead, to get the count by CProductId instead of cpInstanceUuid