### PR TITLE
LPD-18547 - use a text box rather than a password box on the "Forgot Password" screen if a certain property is enabled 

### DIFF
--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
@@ -97,7 +97,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "forgot-password"));
 							<liferay-ui:message arguments="<%= HtmlUtil.escape(login) %>" key="an-email-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question" translateArguments="<%= false %>" />
 						</div>
 
-						<aui:input label="<%= HtmlUtil.escape(LanguageUtil.get(request, user2.getReminderQueryQuestion())) %>" name="answer" type="password" />
+						<aui:input label="<%= HtmlUtil.escape(LanguageUtil.get(request, user2.getReminderQueryQuestion())) %>" name="answer" type='<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_REMINDER_QUERIES_DISPLAY_IN_PLAIN_TEXT, PropsValues.USERS_REMINDER_QUERIES_DISPLAY_IN_PLAIN_TEXT) ? "text" : "password" %>' />
 					</c:if>
 
 					<c:choose>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-18547, tied to LPP.

Changes to hide user security answers due to security concerns were made in [LPS-107063](https://liferay.atlassian.net/browse/LPS-107063). However, at the same time, this LPS added a property (users.reminder.queries.display.answer.in.plain.text) which allows the portal admin to revert back to the previous behavior if they wish. We can see the property was applied to a number of places in commit https://github.com/liferay/liferay-portal-ee/commit/e287417318943d691313bbe80d370212b28b73c8, but notably was not applied to the forgot_password.jsp where the [text box was strictly changed to a password box](https://github.com/liferay/liferay-portal-ee/commit/e287417318943d691313bbe80d370212b28b73c8#diff-cbfdde23acb54464ca00b6ff3e3ae2ab73b5b2477a2211360423538b3cfc772cL102-R102). This change uses the property to determine whether the input box's type is password or text.

AppSec's opinion on the issue can be found here: https://liferay.slack.com/archives/C0A1Z5FJL/p1708569888112929