### PR TITLE
LPD-19194 - the country must also be exported when exporting organizations

### DIFF
--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/CountryStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/CountryStagedModelDataHandler.java
@@ -1,0 +1,118 @@
+package com.liferay.users.admin.internal.exportimport.data.handler;
+
+import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CountryLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.xml.Element;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Author: Lianne Louie
+ */
+@Component(service = StagedModelDataHandler.class)
+public class CountryStagedModelDataHandler
+	extends BaseStagedModelDataHandler<Country> {
+
+	public static final String[] CLASS_NAMES = {Country.class.getName()};
+
+	@Override
+	public void deleteStagedModel(Country country) throws PortalException {
+		_countryLocalService.deleteCountry(country.getCountryId());
+	}
+
+	@Override
+	public void deleteStagedModel(
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException {
+
+		Group group = _groupLocalService.getGroup(groupId);
+
+		Country country = _countryLocalService.getCountryByUuidAndCompanyId(
+			uuid, group.getCompanyId());
+
+		if (country != null) {
+			deleteStagedModel(country);
+		}
+	}
+
+	@Override
+	public List<Country> fetchStagedModelsByUuidAndCompanyId(
+		String uuid, long companyId) {
+
+		return ListUtil.fromArray(
+			_countryLocalService.fetchCountryByUuidAndCompanyId(
+				uuid, companyId));
+	}
+
+	@Override
+	public String[] getClassNames() {
+		return CLASS_NAMES;
+	}
+
+	@Override
+	protected void doExportStagedModel(
+			PortletDataContext portletDataContext, Country country)
+		throws Exception {
+
+		Element countryElement = portletDataContext.getExportDataElement(
+			country);
+
+		portletDataContext.addClassedModel(
+			countryElement, ExportImportPathUtil.getModelPath(country),
+			country);
+	}
+
+	@Override
+	protected void doImportStagedModel(
+			PortletDataContext portletDataContext, Country country)
+		throws Exception {
+
+		ServiceContext serviceContext = portletDataContext.createServiceContext(
+			country);
+
+		Country existingCountry = _countryLocalService.fetchCountryByA2(
+			country.getCompanyId(), country.getA2());
+
+		Country importedCountry = null;
+
+		if (existingCountry == null) {
+			serviceContext.setUuid(country.getUuid());
+
+			importedCountry = _countryLocalService.addCountry(
+				country.getA2(), country.getA3(), country.isActive(),
+				country.isBillingAllowed(), country.getIdd(), country.getName(),
+				country.getNumber(), country.getPosition(),
+				country.isShippingAllowed(), country.isSubjectToVAT(),
+				country.isZipRequired(), serviceContext);
+		}
+		else {
+			importedCountry = _countryLocalService.updateCountry(
+				country.getCountryId(), country.getA2(), country.getA3(),
+				country.isActive(), country.isBillingAllowed(),
+				country.getIdd(), country.getName(), country.getNumber(),
+				country.getPosition(), country.isShippingAllowed(),
+				country.isSubjectToVAT());
+		}
+
+		portletDataContext.importClassedModel(country, importedCountry);
+	}
+
+	@Reference
+	private CountryLocalService _countryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/CountryStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/CountryStagedModelDataHandler.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
 package com.liferay.users.admin.internal.exportimport.data.handler;
 
 import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
@@ -19,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * Author: Lianne Louie
+ * @author Lianne Louie
  */
 @Component(service = StagedModelDataHandler.class)
 public class CountryStagedModelDataHandler

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
@@ -121,7 +121,7 @@ public class OrganizationStagedModelDataHandler
 			}
 
 			_exportAddresses(portletDataContext, exportedOrganization);
-			_exportCountries(portletDataContext, exportedOrganization);
+			_exportCountry(portletDataContext, exportedOrganization);
 			_exportEmailAddresses(portletDataContext, exportedOrganization);
 			_exportOrgLabors(portletDataContext, exportedOrganization);
 			_exportPasswordPolicyRel(portletDataContext, exportedOrganization);
@@ -171,7 +171,7 @@ public class OrganizationStagedModelDataHandler
 
 		Organization importedOrganization = null;
 
-		organization = _updateCountryId(portletDataContext, organization);
+		organization = _importCountry(portletDataContext, organization);
 
 		if (existingOrganization == null) {
 			serviceContext.setUuid(organization.getUuid());
@@ -240,7 +240,7 @@ public class OrganizationStagedModelDataHandler
 		}
 	}
 
-	private void _exportCountries(
+	private void _exportCountry(
 			PortletDataContext portletDataContext, Organization organization)
 		throws Exception {
 
@@ -363,6 +363,33 @@ public class OrganizationStagedModelDataHandler
 		UsersAdminUtil.updateAddresses(
 			Organization.class.getName(),
 			importedOrganization.getOrganizationId(), addresses);
+	}
+
+	private Organization _importCountry(
+			PortletDataContext portletDataContext, Organization organization)
+		throws Exception {
+
+		List<Element> countryElements =
+			portletDataContext.getReferenceDataElements(
+				organization, Country.class);
+
+		if (!countryElements.isEmpty()) {
+			Element countryElement = countryElements.get(0);
+
+			String countryPath = countryElement.attributeValue("path");
+
+			Country country = (Country)portletDataContext.getZipEntryAsObject(
+				countryPath);
+
+			if (country != null) {
+				organization.setCountryId(
+					_countryLocalService.getCountryByA2(
+						portletDataContext.getCompanyId(), country.getA2()
+					).getCountryId());
+			}
+		}
+
+		return organization;
 	}
 
 	private void _importEmailAddresses(
@@ -533,33 +560,6 @@ public class OrganizationStagedModelDataHandler
 		UsersAdminUtil.updateWebsites(
 			Organization.class.getName(),
 			importedOrganization.getOrganizationId(), websites);
-	}
-
-	private Organization _updateCountryId(
-			PortletDataContext portletDataContext, Organization organization)
-		throws PortalException {
-
-		List<Element> countryElements =
-			portletDataContext.getReferenceDataElements(
-				organization, Country.class);
-
-		if (!countryElements.isEmpty()) {
-			Element countryElement = countryElements.get(0);
-
-			String countryPath = countryElement.attributeValue("path");
-
-			Country country = (Country)portletDataContext.getZipEntryAsObject(
-				countryPath);
-
-			if (country != null) {
-				organization.setCountryId(
-					_countryLocalService.getCountryByA2(
-						portletDataContext.getCompanyId(), country.getA2()
-					).getCountryId());
-			}
-		}
-
-		return organization;
 	}
 
 	@Reference

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
@@ -13,6 +13,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Address;
+import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.EmailAddress;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.OrgLabor;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.model.PasswordPolicyRel;
 import com.liferay.portal.kernel.model.Phone;
 import com.liferay.portal.kernel.model.Website;
 import com.liferay.portal.kernel.service.AddressLocalService;
+import com.liferay.portal.kernel.service.CountryLocalService;
 import com.liferay.portal.kernel.service.EmailAddressLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.OrgLaborLocalService;
@@ -119,6 +121,7 @@ public class OrganizationStagedModelDataHandler
 			}
 
 			_exportAddresses(portletDataContext, exportedOrganization);
+			_exportCountries(portletDataContext, exportedOrganization);
 			_exportEmailAddresses(portletDataContext, exportedOrganization);
 			_exportOrgLabors(portletDataContext, exportedOrganization);
 			_exportPasswordPolicyRel(portletDataContext, exportedOrganization);
@@ -168,6 +171,8 @@ public class OrganizationStagedModelDataHandler
 
 		Organization importedOrganization = null;
 
+		organization = _updateCountryId(portletDataContext, organization);
+
 		if (existingOrganization == null) {
 			serviceContext.setUuid(organization.getUuid());
 
@@ -215,6 +220,9 @@ public class OrganizationStagedModelDataHandler
 				portletDataContext, organization, Organization.class,
 				organization.getParentOrganizationId());
 		}
+
+		StagedModelDataHandlerUtil.importReferenceStagedModel(
+			portletDataContext, Country.class, organization.getCountryId());
 	}
 
 	private void _exportAddresses(
@@ -230,6 +238,18 @@ public class OrganizationStagedModelDataHandler
 				portletDataContext, organization, address,
 				PortletDataContext.REFERENCE_TYPE_EMBEDDED);
 		}
+	}
+
+	private void _exportCountries(
+			PortletDataContext portletDataContext, Organization organization)
+		throws Exception {
+
+		Country country = _countryLocalService.getCountry(
+			organization.getCountryId());
+
+		StagedModelDataHandlerUtil.exportReferenceStagedModel(
+			portletDataContext, organization, country,
+			PortletDataContext.REFERENCE_TYPE_EMBEDDED);
 	}
 
 	private void _exportEmailAddresses(
@@ -515,8 +535,38 @@ public class OrganizationStagedModelDataHandler
 			importedOrganization.getOrganizationId(), websites);
 	}
 
+	private Organization _updateCountryId(
+			PortletDataContext portletDataContext, Organization organization)
+		throws PortalException {
+
+		List<Element> countryElements =
+			portletDataContext.getReferenceDataElements(
+				organization, Country.class);
+
+		if (!countryElements.isEmpty()) {
+			Element countryElement = countryElements.get(0);
+
+			String countryPath = countryElement.attributeValue("path");
+
+			Country country = (Country)portletDataContext.getZipEntryAsObject(
+				countryPath);
+
+			if (country != null) {
+				organization.setCountryId(
+					_countryLocalService.getCountryByA2(
+						portletDataContext.getCompanyId(), country.getA2()
+					).getCountryId());
+			}
+		}
+
+		return organization;
+	}
+
 	@Reference
 	private AddressLocalService _addressLocalService;
+
+	@Reference
+	private CountryLocalService _countryLocalService;
 
 	@Reference
 	private EmailAddressLocalService _emailAddressLocalService;

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/internal/exportimport/data/handler/test/OrganizationStagedModelDataHandlerTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/internal/exportimport/data/handler/test/OrganizationStagedModelDataHandlerTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Address;
+import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.EmailAddress;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.OrgLabor;
@@ -19,6 +20,7 @@ import com.liferay.portal.kernel.model.Phone;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.model.Website;
 import com.liferay.portal.kernel.service.AddressLocalServiceUtil;
+import com.liferay.portal.kernel.service.CountryLocalServiceUtil;
 import com.liferay.portal.kernel.service.EmailAddressLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrgLaborLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
@@ -88,6 +90,13 @@ public class OrganizationStagedModelDataHandlerTest
 
 		addDependentStagedModel(
 			dependentStagedModelsMap, Address.class, address);
+
+		Country country = OrganizationTestUtil.addCountry(
+			_organization,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		addDependentStagedModel(
+			dependentStagedModelsMap, Country.class, country);
 
 		EmailAddress emailAddress = OrganizationTestUtil.addEmailAddress(
 			_organization);
@@ -178,6 +187,27 @@ public class OrganizationStagedModelDataHandlerTest
 		Assert.assertNotNull(importedAddress);
 		Assert.assertEquals(
 			organization.getOrganizationId(), importedAddress.getClassPK());
+
+		List<StagedModel> countryDependentStagedModels =
+			dependentStagedModelsMap.get(Country.class.getSimpleName());
+
+		Assert.assertEquals(
+			countryDependentStagedModels.toString(), 1,
+			countryDependentStagedModels.size());
+
+		Country country = (Country)countryDependentStagedModels.get(0);
+
+		Country importedCountry =
+			CountryLocalServiceUtil.fetchCountryByUuidAndCompanyId(
+				country.getUuid(), group.getCompanyId());
+
+		Assert.assertNotNull(importedCountry);
+
+		Country organizationCountry = CountryLocalServiceUtil.getCountry(
+			organization.getCountryId());
+
+		Assert.assertEquals(
+			organizationCountry.getA2(), importedCountry.getA2());
 
 		List<StagedModel> emailAddressDependentStagedModels =
 			dependentStagedModelsMap.get(EmailAddress.class.getSimpleName());

--- a/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
@@ -7,6 +7,7 @@ package com.liferay.portal.kernel.test.util;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Address;
+import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.EmailAddress;
 import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.model.ListTypeConstants;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.model.PasswordPolicy;
 import com.liferay.portal.kernel.model.Phone;
 import com.liferay.portal.kernel.model.Website;
 import com.liferay.portal.kernel.service.AddressLocalServiceUtil;
+import com.liferay.portal.kernel.service.CountryLocalServiceUtil;
 import com.liferay.portal.kernel.service.EmailAddressLocalServiceUtil;
 import com.liferay.portal.kernel.service.ListTypeServiceUtil;
 import com.liferay.portal.kernel.service.OrgLaborLocalServiceUtil;
@@ -25,6 +27,7 @@ import com.liferay.portal.kernel.service.PasswordPolicyRelLocalServiceUtil;
 import com.liferay.portal.kernel.service.PhoneLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WebsiteLocalServiceUtil;
+import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portlet.passwordpoliciesadmin.util.test.PasswordPolicyTestUtil;
 
 import java.util.List;
@@ -93,6 +96,27 @@ public class OrganizationTestUtil {
 			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
 			RandomTestUtil.randomString(), type, 0, 0, listType.getListTypeId(),
 			StringPool.BLANK, false, null);
+	}
+
+	public static Country addCountry(
+		Organization organization, ServiceContext serviceContext)
+		throws Exception {
+
+		Country country = CountryLocalServiceUtil.addCountry(
+			"XY", "XYZ", true, true, null,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomDouble(), true, false,
+			false, serviceContext);
+
+		OrganizationLocalServiceUtil.updateOrganization(
+			organization.getExternalReferenceCode(),
+			organization.getCompanyId(), organization.getOrganizationId(),
+			organization.getParentOrganizationId(), organization.getName(),
+			organization.getType(), organization.getRegionId(),
+			country.getCountryId(), organization.getStatusListTypeId(),
+			organization.getComments(), false, null, false, null);
+
+		return country;
 	}
 
 	public static OrgLabor addOrgLabor(Organization organization)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-19194, tied to LPP.

Organizations can have a country assigned to them, independent of any address. This is saved specifically as a countryID in the Organization object. However, there is no guarantee within Liferay that two separate instances will have identical countryIDs for the same country -- they can differ for any number of reasons such as having different lists of countries in an instance or due to the use of increment in the CountryUpgradeProcess. Therefore when importing we can run into the problem of either having an incorrect country listed (due to the countryID existing, but being assigned to a different country) or an error if the countryID doesn't exist at all.

The solution involves exporting the country, but also matching against the A2 value rather than the countryID since we cannot trust that they'd necessarily match. The A2 is a unique value and therefore should not cause any conflicts, particularly since each country has a [specific value](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) assigned to them.

The existing OrganizationStagedModelDataHandler test was also extended to include the country, similar to how the address, email address, etc are already tested.