### PR TITLE
LPD-20788 - use correct companyID when importing an organization

### DIFF
--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/CountryStagedModelDataHandler.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/CountryStagedModelDataHandler.java
@@ -12,6 +12,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CountryLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -85,7 +86,7 @@ public class CountryStagedModelDataHandler
 		throws Exception {
 
 		Country existingCountry = _countryLocalService.fetchCountryByA2(
-			country.getCompanyId(), country.getA2());
+			CompanyThreadLocal.getCompanyId(), country.getA2());
 
 		Country importedCountry = null;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20788, tied to LPP.

This builds off the work done in https://liferay.atlassian.net/browse/LPD-19194, but makes the adjustment of grabbing the companyID based on CompanyThreadLocal instead of based on the country itself. This prevents potential issues importing in LXC where we may end up accidentally targeting the wrong database partition.