### PR TITLE
LPD-22897 - Administrator can't change accounts in Account Management Widget

### DIFF
--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/util/CommerceAccountHelperImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/util/CommerceAccountHelperImpl.java
@@ -523,8 +523,24 @@ public class CommerceAccountHelperImpl implements CommerceAccountHelper {
 		CommerceChannel commerceChannel =
 			_commerceChannelLocalService.getCommerceChannel(commerceChannelId);
 
-		List<AccountEntry> accountEntries =
-			_accountEntryLocalService.getUserAccountEntries(
+		User currentUser = _userLocalService.fetchUser(userId);
+
+		Role administratorRole = _roleLocalService.getRole(
+			commerceChannel.getCompanyId(), RoleConstants.ADMINISTRATOR);
+
+		List<AccountEntry> accountEntries = null;
+
+		if ((currentUser != null) &&
+			_roleLocalService.hasUserRole(
+				currentUser.getUserId(), administratorRole.getRoleId())) {
+
+			accountEntries = _accountEntryLocalService.getAccountEntries(
+				commerceChannel.getCompanyId(),
+				WorkflowConstants.STATUS_APPROVED, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+		}
+		else {
+			accountEntries = _accountEntryLocalService.getUserAccountEntries(
 				userId, AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT, null,
 				new String[] {
 					AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
@@ -533,6 +549,7 @@ public class CommerceAccountHelperImpl implements CommerceAccountHelper {
 					AccountConstants.ACCOUNT_ENTRY_TYPE_SUPPLIER
 				},
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		}
 
 		for (AccountEntry accountEntry : accountEntries) {
 			if (_isChannelAccountEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-22897

After the changes made by COMMERCE-12663/LPD-13529, admin users can't change to an account they didn't create because the fetch method only returns accounts they created.
I added a check to return all accounts if the current user is an admin