### PR TITLE
LPD-26175 - language selectors do not work on private layouts with no equivalent public layout

### DIFF
--- a/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/user_locale_options.jsp
+++ b/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/user_locale_options.jsp
@@ -22,7 +22,7 @@ Locale userLocale = user.getLocale();
 		<c:if test="<%= LanguageUtil.isAvailableLocale(themeDisplay.getSiteGroupId(), user.getLocale()) || (PortalUtil.isGroupControlPanelPath(themeDisplay.getURLCurrent()) && LanguageUtil.isAvailableLocale(userLocale)) %>">
 			<clay:link
 				cssClass="d-block"
-				href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + user.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&persistState=false&showUserLocaleOptionsMessage=false" %>'
+				href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + user.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&persistState=false&showUserLocaleOptionsMessage=false" + "&privateLayout=" + layout.isPrivateLayout() %>'
 				label='<%= LanguageUtil.format(userLocale, "display-the-page-in-x", userLocale.getDisplayName(userLocale)) %>'
 			/>
 		</c:if>
@@ -31,7 +31,7 @@ Locale userLocale = user.getLocale();
 	<div dir="<%= LanguageUtil.get(request, "lang.dir") %>">
 		<clay:link
 			cssClass="d-block"
-			href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + themeDisplay.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&showUserLocaleOptionsMessage=false" %>'
+			href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + themeDisplay.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&privateLayout=" + layout.isPrivateLayout() + "&showUserLocaleOptionsMessage=false" %>'
 			label='<%= LanguageUtil.format(locale, "set-x-as-your-preferred-language", locale.getDisplayName(locale)) %>'
 		/>
 	</div>

--- a/portal-web/docroot/html/common/themes/user_locale_options.jsp
+++ b/portal-web/docroot/html/common/themes/user_locale_options.jsp
@@ -25,14 +25,14 @@ String currentURL = PortalUtil.getCurrentURL(request);
 		</div>
 
 		<c:if test="<%= LanguageUtil.isAvailableLocale(themeDisplay.getSiteGroupId(), user.getLocale()) %>">
-			<aui:a cssClass="d-block" href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(currentURL) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + user.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&persistState=false&showUserLocaleOptionsMessage=false" %>'>
+			<aui:a cssClass="d-block" href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(currentURL) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + user.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&persistState=false&showUserLocaleOptionsMessage=false" + "&privateLayout=" + layout.isPrivateLayout() %>'>
 				<%= LanguageUtil.format(userLocale, "display-the-page-in-x", userLocale.getDisplayName(userLocale)) %>
 			</aui:a>
 		</c:if>
 	</div>
 
 	<div dir="<%= LanguageUtil.get(request, "lang.dir") %>">
-		<aui:a cssClass="d-block" href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(currentURL) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + themeDisplay.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&showUserLocaleOptionsMessage=false" %>'>
+		<aui:a cssClass="d-block" href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(currentURL) + "&groupId=" + themeDisplay.getScopeGroupId() + "&languageId=" + themeDisplay.getLanguageId() + "&layoutId=" + layout.getLayoutId() + "&privateLayout=" + layout.isPrivateLayout() + "&showUserLocaleOptionsMessage=false" %>'>
 			<%= LanguageUtil.format(locale, "set-x-as-your-preferred-language", locale.getDisplayName(locale)) %>
 		</aui:a>
 	</div>

--- a/util-taglib/src/com/liferay/taglib/ui/LanguageTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/LanguageTag.java
@@ -160,6 +160,9 @@ public class LanguageTag extends IncludeTag {
 
 		Layout layout = themeDisplay.getLayout();
 
+		formAction = HttpComponentsUtil.setParameter(
+			formAction, "privateLayout", layout.isPrivateLayout());
+
 		return HttpComponentsUtil.setParameter(
 			formAction, "layoutId", layout.getLayoutId());
 	}


### PR DESCRIPTION
Hi Brian!

https://liferay.atlassian.net/browse/LPD-26175, tied to LPP

This is a fix for a issue arising from the change made in LPD-20228 where we switched from the language selector using the PLID to having it use the layoutID and groupID. When this happens in servicePreAction, we assume that we can also grab whether it's a privateLayout from the request. This isn't necessarily true and therefore it will resolve as 'false' and will attempt to find a public layout with that layoutID and groupID. If the private layout does not have an equivalent public layout this leads to a 404. To fix this, we're simply adding it as an additional parameter to ensure we grab the correct layout later.