### PR TITLE
LPD-46913 - language will not change correctly if the admin language does not match one of the site's locales

### DIFF
--- a/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -14,6 +14,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.model.Layout" %><%@
+page import="com.liferay.portal.kernel.model.impl.VirtualLayout" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.URLCodec" %>

--- a/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/user_locale_options.jsp
+++ b/modules/apps/portal/portal-user-locale-options-web/src/main/resources/META-INF/resources/dynamic_include/user_locale_options.jsp
@@ -9,6 +9,20 @@
 
 <%
 Locale userLocale = user.getLocale();
+
+long groupId = layout.getGroupId();
+long layoutId = layout.getLayoutId();
+boolean privateLayout = layout.isPrivateLayout();
+
+if (layout instanceof VirtualLayout) {
+	VirtualLayout virtualLayout = (VirtualLayout)layout;
+
+	Layout sourceLayout = virtualLayout.getSourceLayout();
+
+	groupId = sourceLayout.getGroupId();
+	layoutId = sourceLayout.getLayoutId();
+	privateLayout = sourceLayout.isPrivateLayout();
+}
 %>
 
 <liferay-util:buffer
@@ -22,7 +36,7 @@ Locale userLocale = user.getLocale();
 		<c:if test="<%= LanguageUtil.isAvailableLocale(themeDisplay.getSiteGroupId(), user.getLocale()) || (PortalUtil.isGroupControlPanelPath(themeDisplay.getURLCurrent()) && LanguageUtil.isAvailableLocale(userLocale)) %>">
 			<clay:link
 				cssClass="d-block"
-				href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + themeDisplay.getScopeGroupId() + "&privateLayout=" + layout.isPrivateLayout() + "&layoutId=" + layout.getLayoutId() + "&languageId=" + user.getLanguageId() + "&persistState=false&showUserLocaleOptionsMessage=false" %>'
+				href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + groupId + "&privateLayout=" + privateLayout + "&layoutId=" + layoutId + "&languageId=" + user.getLanguageId() + "&persistState=false&showUserLocaleOptionsMessage=false" %>'
 				label='<%= LanguageUtil.format(userLocale, "display-the-page-in-x", userLocale.getDisplayName(userLocale)) %>'
 			/>
 		</c:if>
@@ -31,7 +45,7 @@ Locale userLocale = user.getLocale();
 	<div dir="<%= LanguageUtil.get(request, "lang.dir") %>">
 		<clay:link
 			cssClass="d-block"
-			href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + themeDisplay.getScopeGroupId() + "&privateLayout=" + layout.isPrivateLayout() + "&layoutId=" + layout.getLayoutId() + "&languageId=" + themeDisplay.getLanguageId() + "&showUserLocaleOptionsMessage=false" %>'
+			href='<%= themeDisplay.getPathMain() + "/portal/update_language?redirect=" + URLCodec.encodeURL(themeDisplay.getURLCurrent()) + "&groupId=" + groupId + "&privateLayout=" + privateLayout + "&layoutId=" + layoutId + "&languageId=" + themeDisplay.getLanguageId() + "&showUserLocaleOptionsMessage=false" %>'
 			label='<%= LanguageUtil.format(locale, "set-x-as-your-preferred-language", locale.getDisplayName(locale)) %>'
 		/>
 	</div>

--- a/modules/test/playwright/fixtures/usersAndOrganizationsPagesTest.ts
+++ b/modules/test/playwright/fixtures/usersAndOrganizationsPagesTest.ts
@@ -5,6 +5,7 @@
 
 import {test} from '@playwright/test';
 
+import {UserLocaleOptionsPage} from '../pages/portal-user-locale-options-web/UserLocaleOptionsPage';
 import {SiteConfigurationDetailsPage} from '../pages/site-admin-web/SiteConfigurationDetailsPage';
 import {SiteSettingsPage} from '../pages/site-admin-web/SiteSettingsPage';
 import {ExportUserDataPage} from '../pages/user-associated-data-web/ExportUserDataPage';
@@ -29,6 +30,7 @@ const usersAndOrganizationsPagesTest = test.extend<{
 	siteConfigurationDetailsPage: SiteConfigurationDetailsPage;
 	siteSettingsPage: SiteSettingsPage;
 	teamsPage: TeamsPage;
+	userLocaleOptionsPage: UserLocaleOptionsPage;
 	userPersonalSitePage: UserPersonalSitePage;
 	usersAndOrganizationsPage: UsersAndOrganizationsPage;
 }>({
@@ -61,6 +63,9 @@ const usersAndOrganizationsPagesTest = test.extend<{
 	},
 	teamsPage: async ({page}, use) => {
 		await use(new TeamsPage(page));
+	},
+	userLocaleOptionsPage: async ({page}, use) => {
+		await use(new UserLocaleOptionsPage(page));
 	},
 	userPersonalSitePage: async ({page}, use) => {
 		await use(new UserPersonalSitePage(page));

--- a/modules/test/playwright/pages/portal-user-locale-options-web/UserLocaleOptionsPage.ts
+++ b/modules/test/playwright/pages/portal-user-locale-options-web/UserLocaleOptionsPage.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {waitForAlert} from '../../utils/waitForAlert';
+export class UserLocaleOptionsPage {
+	readonly languageChangeLink : Locator;
+	readonly page : Page;
+
+	constructor (page : Page) {
+		this.languageChangeLink = page.getByRole('link', {name: "Display the page in"})
+		this.page = page;
+	}
+
+	async changeLanguageWithAlert() {
+		await waitForAlert(this.page, "This page is displayed in", {autoClose: false, type: 'info'});
+
+		await this.languageChangeLink.click();
+	}
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -84,6 +84,7 @@ import {config as portalSecurityAuditWebConfig} from './tests/portal-security-au
 import {config as portalSecurityScriptManagementWebConfig} from './tests/portal-security-script-management-web/config';
 import {config as portalSecurityServiceAccessPolicyService} from './tests/portal-security-service-access-policy-service/config';
 import {config as portalToolsRestBuilderTestImpl} from './tests/portal-tools-rest-builder-test-impl/config';
+import {config as portalUserLocaleOptionsConfig} from './tests/portal-user-locale-options-web/config';
 import {config as portalWebConfig} from './tests/portal-web/config';
 import {config as portalWorkflowKaleoDesignerWebConfig} from './tests/portal-workflow-kaleo-designer-web/config';
 import {config as portalWorkflowTaskWebConfig} from './tests/portal-workflow-task-web/config';
@@ -208,6 +209,7 @@ export default defineConfig({
 		portalSecurityScriptManagementWebConfig,
 		portalSecurityServiceAccessPolicyService,
 		portalToolsRestBuilderTestImpl,
+		portalUserLocaleOptionsConfig,
 		portalWebConfig,
 		portalWorkflowKaleoDesignerWebConfig,
 		portalWorkflowTaskWebConfig,

--- a/modules/test/playwright/tests/portal-user-locale-options-web/config.ts
+++ b/modules/test/playwright/tests/portal-user-locale-options-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-user-locale-options-web',
+	testDir: 'tests/portal-user-locale-options-web',
+};

--- a/modules/test/playwright/tests/portal-user-locale-options-web/test.properties
+++ b/modules/test/playwright/tests/portal-user-locale-options-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Users and Organizations

--- a/modules/test/playwright/tests/portal-user-locale-options-web/userLocaleOptions.spec.ts
+++ b/modules/test/playwright/tests/portal-user-locale-options-web/userLocaleOptions.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {siteSettingsPagesTest} from '../../fixtures/siteSettingsPagesTest';
+import {usersAndOrganizationsPagesTest} from '../../fixtures/usersAndOrganizationsPagesTest';
+import getRandomString from '../../utils/getRandomString';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	dataApiHelpersTest,
+	loginTest(),
+	siteSettingsPagesTest,
+	usersAndOrganizationsPagesTest
+);
+
+test('LPD-46913 language should change properly for admins even if the site does not have the admin language', async ({
+	apiHelpers,
+	siteSettingsLocalizationPage,
+	siteSettingsPage,
+	page,
+	userLocaleOptionsPage
+}) => {
+	const site = await apiHelpers.headlessSite.createSite({
+		name: getRandomString(),
+	});
+
+	apiHelpers.data.push({id: site.id, type: 'site'});
+
+	await siteSettingsLocalizationPage.goto(site.friendlyUrlPath);
+
+	await siteSettingsLocalizationPage.setCustomDefaultLanguage(
+		'Spanish (Spain)',
+		site.friendlyUrlPath
+	);
+
+	await siteSettingsLocalizationPage.disableAllLanguagesExceptSp(
+		site.friendlyUrlPath
+	);
+
+	const siteURL = `/es/group${site.friendlyUrlPath}`
+	await page.goto(siteURL);
+
+	await siteSettingsPage.goToSiteSetting('Localización', 'Idiomas', site.friendlyUrlPath);
+
+	await userLocaleOptionsPage.changeLanguageWithAlert();
+
+	expect (siteSettingsLocalizationPage.customDefaultLanguageOption).toBeVisible();
+});


### PR DESCRIPTION
Hi @brianikim,

https://liferay.atlassian.net/browse/LPD-46913, tied to LPP.

I'm sending this to you primarily because you mentioned previously when first assigning this to me that you weren't sure about the intended solution. If you feel this may not match the proper solution let me know and I'll look into it further. 

The issue we currently are seeing here is that we specifically allow admins who do not have a default language that matches a site language to still work in their own language per LPS-154862. However, when the changes were made in LPD-20228 away from PLIDs due to security concerns, we started returning the incorrect layout -- specifically, we'd end up returning the layout of the site not of the control panel (you can verify this by noting that the layout corresponding to the 'plid' is the control panel one, but the 'layout.getGroupId() returns a different value). Returning the incorrect layout was typically not an issue since most sites often share all locales, but in this specific case -- since the locale is not available in the layout being returned -- we fail the check in UpdateLanguageAction and therefore the language is never changed properly. I've fixed the issue by returning the correct layout which is the source layout. In cases where there is only one layout (AKA it's not a virtual layout), it should still function properly per the logic. 