### PR TITLE
LPD-25497

### DIFF
--- a/modules/apps/commerce/commerce-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce API
 Bundle-SymbolicName: com.liferay.commerce.api
-Bundle-Version: 94.1.1
+Bundle-Version: 94.2.0
 Export-Package:\
 	com.liferay.commerce.address,\
 	com.liferay.commerce.checkout.helper,\

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/RequiredOrderItemOptionException.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/exception/RequiredOrderItemOptionException.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Alessio Antonio Rendina
+ */
+public class RequiredOrderItemOptionException extends PortalException {
+
+	public RequiredOrderItemOptionException() {
+	}
+
+	public RequiredOrderItemOptionException(String msg) {
+		super(msg);
+	}
+
+	public RequiredOrderItemOptionException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public RequiredOrderItemOptionException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/exception/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_publisher/render/list/entry/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_publisher/render/list/entry/view.jsp
@@ -15,6 +15,8 @@ CPContentHelper cpContentHelper = (CPContentHelper)request.getAttribute(CPConten
 CPCatalogEntry cpCatalogEntry = cpContentHelper.getCPCatalogEntry(request);
 
 boolean hasMultipleCPSkus = cpContentHelper.hasMultipleCPSkus(cpCatalogEntry);
+
+boolean hasOptions = cpContentHelper.hasCPDefinitionOptionRels(cpCatalogEntry.getCPDefinitionId());
 %>
 
 <div class="cp-renderer">
@@ -101,7 +103,7 @@ boolean hasMultipleCPSkus = cpContentHelper.hasMultipleCPSkus(cpCatalogEntry);
 
 			<div>
 				<c:choose>
-					<c:when test="<%= !hasMultipleCPSkus && (cpSku != null) %>">
+					<c:when test="<%= !hasMultipleCPSkus && (cpSku != null) && !hasOptions %>">
 						<div class="mt-2">
 							<commerce-ui:add-to-cart
 								alignment="full-width"

--- a/modules/apps/commerce/commerce-service/service.xml
+++ b/modules/apps/commerce/commerce-service/service.xml
@@ -979,5 +979,6 @@
 		<exception>GuestCartItemMaxAllowed</exception>
 		<exception>GuestCartMaxAllowed</exception>
 		<exception>ProductBundle</exception>
+		<exception>RequiredOrderItemOption</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.commerce.exception.CommerceOrderValidatorException;
 import com.liferay.commerce.exception.GuestCartItemMaxAllowedException;
 import com.liferay.commerce.exception.NoSuchOrderItemException;
 import com.liferay.commerce.exception.ProductBundleException;
+import com.liferay.commerce.exception.RequiredOrderItemOptionException;
 import com.liferay.commerce.internal.search.CommerceOrderItemIndexer;
 import com.liferay.commerce.internal.util.CommercePriceConverterUtil;
 import com.liferay.commerce.inventory.constants.CommerceInventoryConstants;
@@ -40,9 +41,12 @@ import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.exception.NoSuchCPInstanceException;
 import com.liferay.commerce.product.exception.NoSuchCPInstanceUnitOfMeasureException;
 import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.commerce.product.model.CPDefinitionOptionRel;
 import com.liferay.commerce.product.model.CPInstance;
 import com.liferay.commerce.product.model.CPInstanceUnitOfMeasure;
 import com.liferay.commerce.product.model.CPMeasurementUnit;
+import com.liferay.commerce.product.model.CPOption;
+import com.liferay.commerce.product.model.CPOptionValue;
 import com.liferay.commerce.product.option.CommerceOptionValue;
 import com.liferay.commerce.product.option.CommerceOptionValueHelper;
 import com.liferay.commerce.product.service.CPDefinitionLocalService;
@@ -65,12 +69,14 @@ import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.json.JSONObjectImpl;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
@@ -1377,6 +1383,8 @@ public class CommerceOrderItemLocalServiceImpl
 			GetterUtil.getBoolean(
 				serviceContext.getAttribute("validateOrder"), true));
 
+		String sanitizedJSON = _validateOptionsJSON(json, cpInstance);
+
 		long commerceOrderItemId = counterLocalService.increment();
 
 		CommerceOrderItem commerceOrderItem =
@@ -1393,7 +1401,7 @@ public class CommerceOrderItemLocalServiceImpl
 		commerceOrderItem.setParentCommerceOrderItemId(
 			parentCommerceOrderItemId);
 		commerceOrderItem.setFreeShipping(cpDefinition.isFreeShipping());
-		commerceOrderItem.setJson(json);
+		commerceOrderItem.setJson(sanitizedJSON);
 		commerceOrderItem.setManuallyAdjusted(false);
 		commerceOrderItem.setNameMap(cpDefinition.getNameMap());
 		commerceOrderItem.setQuantity(quantity);
@@ -2427,6 +2435,11 @@ public class CommerceOrderItemLocalServiceImpl
 			GetterUtil.getBoolean(
 				serviceContext.getAttribute("validateOrder"), true));
 
+		String sanitizedJSON = _validateOptionsJSON(
+			json,
+			_cpInstanceLocalService.getCPInstance(
+				commerceOrderItem.getCPInstanceId()));
+
 		_updateCommerceInventoryBookedQuantity(
 			userId, commerceOrderItem,
 			commerceOrderItem.getCommerceInventoryBookedQuantityId(), quantity,
@@ -2434,7 +2447,7 @@ public class CommerceOrderItemLocalServiceImpl
 
 		commerceOrder = _updateWorkflow(userId, commerceOrder);
 
-		commerceOrderItem.setJson(json);
+		commerceOrderItem.setJson(sanitizedJSON);
 		commerceOrderItem.setQuantity(quantity);
 
 		if (commerceOrder.isOpen()) {
@@ -2494,6 +2507,11 @@ public class CommerceOrderItemLocalServiceImpl
 			GetterUtil.getBoolean(
 				serviceContext.getAttribute("validateOrder"), true));
 
+		String sanitizedJSON = _validateOptionsJSON(
+			json,
+			_cpInstanceLocalService.getCPInstance(
+				commerceOrderItem.getCPInstanceId()));
+
 		_updateCommerceInventoryBookedQuantity(
 			userId, commerceOrderItem,
 			commerceOrderItem.getCommerceInventoryBookedQuantityId(), quantity,
@@ -2501,7 +2519,7 @@ public class CommerceOrderItemLocalServiceImpl
 
 		_updateWorkflow(userId, commerceOrder);
 
-		commerceOrderItem.setJson(json);
+		commerceOrderItem.setJson(sanitizedJSON);
 		commerceOrderItem.setQuantity(quantity);
 		commerceOrderItem.setExpandoBridgeAttributes(serviceContext);
 
@@ -2614,6 +2632,128 @@ public class CommerceOrderItemLocalServiceImpl
 					commerceCartValidatorResults);
 			}
 		}
+	}
+
+	private String _validateOptionsJSON(String json, CPInstance cpInstance)
+		throws PortalException {
+
+		List<CPDefinitionOptionRel> cpDefinitionOptionRels =
+			_cpDefinitionOptionRelLocalService.getCPDefinitionOptionRels(
+				cpInstance.getCPDefinitionId());
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		if (JSONUtil.isJSONArray(json)) {
+			jsonArray = _jsonFactory.createJSONArray(json);
+		}
+
+		for (CPDefinitionOptionRel cpDefinitionOptionRel :
+				cpDefinitionOptionRels) {
+
+			JSONObject optionJSONObject = null;
+
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				String key = jsonObject.getString("key");
+
+				if (key.equals(cpDefinitionOptionRel.getKey())) {
+					optionJSONObject = jsonObject;
+
+					break;
+				}
+			}
+
+			CPOption cpOption = cpDefinitionOptionRel.getCPOption();
+
+			List<CPOptionValue> cpOptionValues = cpOption.getCPOptionValues();
+
+			if (cpOption.isRequired()) {
+				if ((optionJSONObject == null) ||
+					optionJSONObject.getString(
+						"value"
+					).isEmpty()) {
+
+					throw new RequiredOrderItemOptionException();
+				}
+
+				String commerceOptionTypeKey =
+					cpOption.getCommerceOptionTypeKey();
+
+				if (commerceOptionTypeKey.matches("select|radio")) {
+					boolean found = false;
+
+					for (CPOptionValue cpOptionValue : cpOptionValues) {
+						String skuOptionValueKey = optionJSONObject.getString(
+							"skuOptionValueKey");
+
+						if (Objects.equals(
+								cpOptionValue.getKey(), skuOptionValueKey)) {
+
+							found = true;
+
+							break;
+						}
+					}
+
+					if (!found) {
+						throw new RequiredOrderItemOptionException();
+					}
+				}
+				else if (commerceOptionTypeKey.equals("checkbox")) {
+				}
+				else if (commerceOptionTypeKey.equals("checkbox_multiple")) {
+				}
+			}
+			else if (cpOption.isSkuContributor()) {
+				if (optionJSONObject == null) {
+					throw new RequiredOrderItemOptionException();
+				}
+				else if (optionJSONObject.getString(
+							"value"
+						).isEmpty()) {
+
+					CPOptionValue cpOptionValue = cpOptionValues.get(0);
+
+					JSONObject jsonObject = new JSONObjectImpl(
+					).put(
+						"skuOptionName",
+						cpDefinitionOptionRel.getNameCurrentValue()
+					).put(
+						"quantity", String.valueOf(0)
+					).put(
+						"price", String.valueOf(0)
+					).put(
+						"priceType", cpDefinitionOptionRel.getPriceType()
+					).put(
+						"skuOptionKey", cpDefinitionOptionRel.getKey()
+					).put(
+						"skuOptionValueKey", cpOptionValue.getKey()
+					).put(
+						"skuOptionValueNames",
+						_jsonFactory.createJSONArray(
+						).put(
+							cpOptionValue.getNameCurrentValue()
+						)
+					).put(
+						"value", cpOptionValue.getNameCurrentValue()
+					).put(
+						"key", cpDefinitionOptionRel.getKey()
+					).put(
+						"skuId", new JSONObjectImpl()
+					);
+
+					jsonArray.put(jsonObject);
+				}
+			}
+
+			// scenario 3 - Missing optional data
+
+			else {
+			}
+		}
+
+		return jsonArray.toString();
 	}
 
 	private void _validateParentCommerceOrderId(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/jaxrs/exception/mapper/RequiredOrderItemExceptionMapper.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/jaxrs/exception/mapper/RequiredOrderItemExceptionMapper.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.commerce.admin.order.internal.jaxrs.exception.mapper;
+
+import com.liferay.commerce.exception.RequiredOrderItemOptionException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author João Victor Cordeiro
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Commerce.Admin.Order.RequiredOrderItemExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class RequiredOrderItemExceptionMapper
+	extends BaseExceptionMapper<RequiredOrderItemOptionException> {
+
+	@Override
+	protected Problem getProblem(
+		RequiredOrderItemOptionException requiredOrderItemOptionException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST, "Required option value is invalid.");
+	}
+
+}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/jaxrs/exception/mapper/RequiredOrderItemExceptionMapper.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/jaxrs/exception/mapper/RequiredOrderItemExceptionMapper.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.commerce.delivery.cart.internal.jaxrs.exception.mapper;
+
+import com.liferay.commerce.exception.RequiredOrderItemOptionException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author João Victor Cordeiro
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Commerce.Delivery.Cart.RequiredOrderItemExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class RequiredOrderItemExceptionMapper
+	extends BaseExceptionMapper<RequiredOrderItemOptionException> {
+
+	@Override
+	protected Problem getProblem(
+		RequiredOrderItemOptionException requiredOrderItemOptionException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST, "Required option value is invalid.");
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-25497

the _validateOptionsJSON method handles the validation of wrong/missing required option values for the 3 scenarios. i will run through each CPDefinitionOptionRel and check if there is a value to it in the options Json.
While iterating, if it's a [required option](https://github.com/victorcdp/liferay-portal/blob/e4c31b8f3afbe529031568fbb2149c732b25e0a3/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java#L2671-L2707) (scenario 2), it will check if the option is included in the json, and if it has a valid value. ("checkbox" and "checkbox_multiple" validation isn't done yet)
if it's a [SkuContributor](https://github.com/victorcdp/liferay-portal/blob/e4c31b8f3afbe529031568fbb2149c732b25e0a3/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderItemLocalServiceImpl.java#L2708-L2748)  (scenario 1), and it has a missing/invalid value, it will fill the json with a default value.

Scenario 3 is missing, and the whole thing can be optimized. There are still a quite a kinks to work out