### PR TITLE
LPD-97403 Ensure Commerce Search Results returns products

### DIFF
--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/java/com/liferay/commerce/product/content/search/web/internal/portlet/shared/search/CPSearchResultsPortletSharedSearchContributor.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
@@ -129,6 +130,8 @@ public class CPSearchResultsPortletSharedSearchContributor
 			portletSharedSearchSettings.getSearchContext();
 
 		searchContext.setAttribute(CPField.PUBLISHED, Boolean.TRUE);
+		searchContext.setAttribute(
+			SearchContextAttributes.ATTRIBUTE_KEY_EXECUTE_SEARCH, Boolean.TRUE);
 		searchContext.setEntryClassNames(
 			new String[] {CPDefinition.class.getName()});
 

--- a/modules/test/playwright/tests/commerce/commerce-product-content-search-web/main/searchResults.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-search-web/main/searchResults.spec.ts
@@ -101,3 +101,86 @@ test(
 		await expect(page.getByText(product2.name.en_US)).toBeVisible();
 	}
 );
+
+test(
+	'Commerce search results should still display when a search bar on the same page targets a different destination',
+	{tag: ['@LPD-97403']},
+	async ({apiHelpers, page, searchPage, site}) => {
+		await apiHelpers.headlessCommerceAdminChannel.postChannel({
+			siteGroupId: site.id,
+		});
+
+		const catalog =
+			await apiHelpers.headlessCommerceAdminCatalog.postCatalog();
+
+		const product1 =
+			await apiHelpers.headlessCommerceAdminCatalog.postProduct({
+				catalogId: catalog.id,
+			});
+
+		const product2 =
+			await apiHelpers.headlessCommerceAdminCatalog.postProduct({
+				catalogId: catalog.id,
+			});
+
+		const searchLayout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getWidgetDefinition({
+					id: getRandomString(),
+					widgetName:
+						'com_liferay_commerce_product_content_search_web_internal_portlet_CPSearchResultsPortlet',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getWidgetDefinition({
+					id: getRandomString(),
+					widgetConfig: {
+						allowEmptySearches: 'true',
+						destination: searchLayout.friendlyUrlPath,
+						keywordsParameterName: 'q',
+						searchScope: 'everything',
+					},
+					widgetName:
+						'com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet',
+				}),
+				getWidgetDefinition({
+					id: getRandomString(),
+					widgetConfig: {
+						allowEmptySearches: 'true',
+					},
+					widgetName:
+						'com_liferay_portal_search_web_search_options_portlet_SearchOptionsPortlet',
+				}),
+				getWidgetDefinition({
+					id: getRandomString(),
+					widgetName:
+						'com_liferay_commerce_product_content_search_web_internal_portlet_CPSearchResultsPortlet',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await page.goto(`/web/${site.name}/${layout.friendlyUrlPath}`);
+
+		await expect(searchPage.searchBarInputInMainContent).toBeVisible();
+
+		await expect(page.getByText(product1.name.en_US)).toBeVisible();
+
+		await expect(page.getByText(product2.name.en_US)).toBeVisible();
+
+		await searchPage.searchBarInputInMainContent.fill(product2.name.en_US);
+		await searchPage.searchBarInputInMainContent.press('Enter');
+
+		await page.waitForURL(`**${searchLayout.friendlyUrlPath}**`);
+
+		await expect(page.getByText(product2.name.en_US)).toBeVisible();
+
+		await expect(page.getByText(product1.name.en_US)).not.toBeVisible();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97403

## What Is Being Fixed

The Commerce Search Results widget stopped returning any products. This
surfaced on a page that pairs the widget with a Search Bar and a Search
Options portlet (with empty searches allowed) — especially when the
Search Bar targets a different destination page. In that case the shared
search framework never triggered execution on the current page, so the
Commerce Search Results widget rendered empty.

## How It Is Being Fixed

CPSearchResultsPortletSharedSearchContributor now sets the
"search.execute.search" (ATTRIBUTE_KEY_EXECUTE_SEARCH) attribute to TRUE
on its search context. This forces the Commerce Search Results widget to
always execute its own search, independent of whether another search bar
on the page contributed keywords or pointed elsewhere.

A Playwright test covers the scenario: with a Search Bar targeting a
different destination on the same page, the widget still displays all
products, and searching routes the keywords to the destination page's
own Commerce Search Results widget, which returns only the match.

## PR Check

**pr-check: PASS** — tested on `3a3988b1cc059ffa68a0aeca819d59b8457f2af2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "3a3988b1cc059ffa68a0aeca819d59b8457f2af2"} -->
